### PR TITLE
Disable LC003 and LC005 for DotNet var/param names

### DIFF
--- a/Design/Rule0003DoNotUseObjectIDsInVariablesOrProperties.cs
+++ b/Design/Rule0003DoNotUseObjectIDsInVariablesOrProperties.cs
@@ -85,6 +85,11 @@ namespace BusinessCentral.LinterCop.Design
 
                 foreach (IParameterSymbol parameter in method.Parameters)
                 {
+                    if (parameter.ParameterType.NavTypeKind == NavTypeKind.DotNet)
+                    {
+                        continue;
+                    }
+
                     if (ctx.Node.GetLocation().SourceSpan.End == parameter.DeclaringSyntaxReference.GetSyntax(CancellationToken.None).Span.End)
                     {
                         correctName = GetCorrectName(parameter.ParameterType.NavTypeKind.ToString(), parameter.ParameterType.ToString());
@@ -98,7 +103,11 @@ namespace BusinessCentral.LinterCop.Design
                 }
                 try
                 {
-                    IReturnValueSymbol returnValue = (IReturnValueSymbol)method.ReturnValueSymbol;
+                    IReturnValueSymbol returnValue = method.ReturnValueSymbol;
+                    if (returnValue.ReturnType.NavTypeKind == NavTypeKind.DotNet)
+                    {
+                        return;
+                    }
 
                     if (ctx.Node.GetLocation().SourceSpan.End == returnValue.DeclaringSyntaxReference.GetSyntax(CancellationToken.None).Span.End)
                     {

--- a/Design/Rule0005VariableCasingShouldNotDIfferFromDeclaration.cs
+++ b/Design/Rule0005VariableCasingShouldNotDIfferFromDeclaration.cs
@@ -48,6 +48,11 @@ namespace BusinessCentral.LinterCop.Design
         {
             foreach (var node in ctx.Symbol.DeclaringSyntaxReference.GetSyntax().DescendantNodesAndTokens().Where(n => IsValidToken(n)))
             {
+                if (node.Kind.ToString().StartsWith("DotNet"))
+                {
+                    continue;
+                }
+
                 if (node.IsToken)
                     if (SyntaxFactory.Token(node.Kind).ToString() != node.ToString())
                         ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0005VariableCasingShouldNotDIfferFromDeclaration, node.GetLocation(), new object[] { SyntaxFactory.Token(node.Kind), "" }));


### PR DESCRIPTION
For the time being, until #95 gets resolved in a better way, this PR will disable the checks for variables, parameters and also return variable names with DotNet as data type (even though the latter cannot have `DotNet` as data-type).
Note that the check for the casing of `DotNet` itself still works, but the subtype check is skipped.