### PR TITLE
Add MethodKind validation to Rule0002

### DIFF
--- a/Design/Rule0002CommitMustBeExplainedByComment.cs
+++ b/Design/Rule0002CommitMustBeExplainedByComment.cs
@@ -19,7 +19,7 @@ namespace BusinessCentral.LinterCop.Design
         if (ctx.ContainingSymbol.IsObsoletePending ||ctx.ContainingSymbol.IsObsoleteRemoved) return;
 
         IInvocationExpression operation = (IInvocationExpression)ctx.Operation;
-        if (operation.TargetMethod.Name.ToUpper() == "COMMIT")
+        if (operation.TargetMethod.Name.ToUpper() == "COMMIT" && operation.TargetMethod.MethodKind == MethodKind.BuiltInMethod)
         {
                 foreach (SyntaxTrivia trivia in operation.Syntax.Parent.GetLeadingTrivia())
                 {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44637996/196394765-947cbbfb-e69d-4bcc-a2a2-897e1b3b85e1.png)

The goal is to exclude the warning of LC0002 when the Commit is a custom procedure;

![image](https://user-images.githubusercontent.com/44637996/196395088-56617e1d-bfcd-4fdf-83ef-7a6b45432eb5.png)