### PR TITLE
Disable Rule 0016 "Caption is missing." for objects of the the API

### DIFF
--- a/Design/Rule0016CheckForMissingCaptions.cs
+++ b/Design/Rule0016CheckForMissingCaptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿using BusinessCentral.LinterCop.Helpers;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System;
 using System.Collections.Immutable;
@@ -25,6 +26,12 @@ namespace BusinessCentral.LinterCop.Design
         {
             if (context.Symbol.IsObsoletePending || context.Symbol.IsObsoleteRemoved) return;
             if (context.Symbol.GetContainingObjectTypeSymbol().IsObsoletePending || context.Symbol.GetContainingObjectTypeSymbol().IsObsoleteRemoved) return;
+
+            LinterSettings.Create();
+            if (!(LinterSettings.instance.enableRule0016ForApiObjects))
+            {
+                if (context.Symbol.GetContainingObjectTypeSymbol().GetProperty(PropertyKind.PageType).ValueText == PageTypeKind.API.ToString()) return;
+            }
 
             if (context.Symbol.Kind == SymbolKind.Control)
             {

--- a/Helpers/LinterSettings.cs
+++ b/Helpers/LinterSettings.cs
@@ -8,6 +8,7 @@ namespace BusinessCentral.LinterCop.Helpers
         public int cyclomaticComplexetyThreshold = 8;
         public int maintainablityIndexThreshold = 20;
         public bool enableRule0011ForTableFields = false;
+        public bool enableRule0016ForApiObjects = false;
         static public LinterSettings instance;
 
         static public void Create()

--- a/LinterCop.json
+++ b/LinterCop.json
@@ -1,5 +1,6 @@
 {
   "cyclomaticComplexetyThreshold": 8,
   "maintainablityIndexThreshold": 20,
-  "enableRule0011ForTableFields": false
+  "enableRule0011ForTableFields": false,
+  "enableRule0016ForApiObjects": false
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Further note that you should have BcContainerHelper version 2.0.16 (or newer) in
 |[LC0013](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0013)|Any table with a single field in the PK of type code or text, should have set `NotBlank` on the PK field.|Warning|
 |[LC0014](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0014)|The Caption of permissionset objects should not exceed the maximum length.|Warning|
 |[LC0015](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0015)|All application objects should be covered by at least one permission set in the extension.|Warning|
-|[LC0016](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0016)|Caption is missing.|Warning|
+|[LC0016](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0016)|Caption is missing. Optionally this can also be activated for fields on API objects with the setting `enableRule0016ForApiObjects`.|Warning|
 |[LC0017](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0017)|Writing to a FlowField is not common. Add a comment to explain this.|Warning|
 |[LC0018](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0018)|Events in internal codeunits are not accessible to extensions and should therefore be avoided.|Info|
 |[LC0019](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0019)|If Data Classification is set on the Table. Fields do not need the same classification.|Info|


### PR DESCRIPTION
Related to issue: https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/190.

Because this could be experienced as a breaking change I've provided a setting in the LinterCop.json to enable the current behavior. When an external application uses the metadata of the API's, like the PowerPlatform, you can make the rule 0016 more strict. Not sure if there's a performance penalty I should consider on getting/reading the setting from the json-file?