### PR TITLE
Fix: Spelling issues in LinterCop.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@
 /Resources/Microsoft.Dynamics.Nav.Analyzers.Common.dll
 /Resources/Microsoft.CodeAnalysis.dll
 /packages/System.Composition.AttributedModel.5.0.1
-.vscode/
+.vscode/**
+!.vscode/extensions.json
+!.vscode/settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "streetsidesoftware.code-spell-checker"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "cyclomatic",
+        "Halstead",
+        "Newtonsoft"
+    ]
+}

--- a/Design/Rule0009CodeMetrics.cs
+++ b/Design/Rule0009CodeMetrics.cs
@@ -27,21 +27,21 @@ namespace BusinessCentral.LinterCop.Design
 
             LinterSettings.Create();
             if (LinterSettings.instance != null)
-                if (cyclomaticComplexity >= LinterSettings.instance.cyclomaticComplexetyThreshold || Math.Round(HalsteadVolume) <= LinterSettings.instance.maintainablityIndexThreshold)
+                if (cyclomaticComplexity >= LinterSettings.instance.cyclomaticComplexityThreshold || Math.Round(HalsteadVolume) <= LinterSettings.instance.maintainabilityIndexThreshold)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0010CodeMetricsWarning, context.OwningSymbol.GetLocation(), new object[] { cyclomaticComplexity, Math.Round(HalsteadVolume) }));
                     return;
                 }
 
-            if (cyclomaticComplexity >= LinterSettings.instance.cyclomaticComplexetyThreshold || Math.Round(HalsteadVolume) <= LinterSettings.instance.maintainablityIndexThreshold)
+            if (cyclomaticComplexity >= LinterSettings.instance.cyclomaticComplexityThreshold || Math.Round(HalsteadVolume) <= LinterSettings.instance.maintainabilityIndexThreshold)
             {
-                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0010CodeMetricsWarning, context.OwningSymbol.GetLocation(), new object[] { LinterSettings.instance.cyclomaticComplexetyThreshold, Math.Round(HalsteadVolume) }));
+                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0010CodeMetricsWarning, context.OwningSymbol.GetLocation(), new object[] { LinterSettings.instance.cyclomaticComplexityThreshold, Math.Round(HalsteadVolume) }));
                 return;
             }
             context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0009CodeMetricsInfo, context.OwningSymbol.GetLocation(), new object[] { cyclomaticComplexity, Math.Round(HalsteadVolume)}));
         }
 
-        private static double GetHalsteadVolume(SyntaxNode CodeBlock, ref CodeBlockAnalysisContext context,int cyclomaticComplexety)
+        private static double GetHalsteadVolume(SyntaxNode CodeBlock, ref CodeBlockAnalysisContext context,int cyclomaticComplexity)
         {
             try
             {
@@ -65,7 +65,7 @@ namespace BusinessCentral.LinterCop.Design
                 double HalsteadVolume = N * Math.Log(n, 2);
 
                 //171−5.2lnV−0.23G−16.2lnL
-                return Math.Max(0, (171 - 5.2 * Math.Log(HalsteadVolume) - 0.23 * cyclomaticComplexety - 16.2 * Math.Log(triviaLinesCount)) * 100 / 171);
+                return Math.Max(0, (171 - 5.2 * Math.Log(HalsteadVolume) - 0.23 * cyclomaticComplexity - 16.2 * Math.Log(triviaLinesCount)) * 100 / 171);
 
             }
             catch (System.NullReferenceException)

--- a/Helpers/LinterSettings.cs
+++ b/Helpers/LinterSettings.cs
@@ -5,8 +5,8 @@ namespace BusinessCentral.LinterCop.Helpers
 {
     class LinterSettings
     {
-        public int cyclomaticComplexetyThreshold = 8;
-        public int maintainablityIndexThreshold = 20;
+        public int cyclomaticComplexityThreshold = 8;
+        public int maintainabilityIndexThreshold = 20;
         public bool enableRule0011ForTableFields = false;
         static public LinterSettings instance;
 
@@ -19,9 +19,12 @@ namespace BusinessCentral.LinterCop.Helpers
                     StreamReader r = File.OpenText("LinterCop.json");
                     string json = r.ReadToEnd();
                     r.Close();
-                    instance = JsonConvert.DeserializeObject<LinterSettings>(json);
-                    if (instance == null)
-                        instance = new LinterSettings();
+                    instance = new LinterSettings();
+
+                    InternalLinterSettings internalInstance = JsonConvert.DeserializeObject<InternalLinterSettings>(json);
+                    instance.cyclomaticComplexityThreshold = internalInstance.cyclomaticComplexityThreshold ?? internalInstance.cyclomaticComplexetyThreshold ?? instance.cyclomaticComplexityThreshold;
+                    instance.maintainabilityIndexThreshold = internalInstance.maintainabilityIndexThreshold ?? internalInstance.maintainablityIndexThreshold ?? instance.maintainabilityIndexThreshold;
+                    instance.enableRule0011ForTableFields = internalInstance.enableRule0011ForTableFields;
                 }
                 catch
                 {
@@ -29,5 +32,14 @@ namespace BusinessCentral.LinterCop.Helpers
                 }
             }
         }
+    }
+    internal class InternalLinterSettings
+    {
+        public int? cyclomaticComplexityThreshold;
+        public int? maintainabilityIndexThreshold;
+        public int? cyclomaticComplexetyThreshold; // Misspelled, deprecated
+        public int? maintainablityIndexThreshold; // Misspelled, deprecated
+        public bool enableRule0011ForTableFields = false;
+
     }
 }

--- a/LinterCop.json
+++ b/LinterCop.json
@@ -1,5 +1,5 @@
 {
-  "cyclomaticComplexetyThreshold": 8,
-  "maintainablityIndexThreshold": 20,
+  "cyclomaticComplexityThreshold": 8,
+  "maintainabilityIndexThreshold": 20,
   "enableRule0011ForTableFields": false
 }


### PR DESCRIPTION
An attempt to fix #216 with maintained backward compatibility.

A PR for the VS Code extension will follow, with syntax for LinterCop.json.

Also added Code Spell Checker as a recommended extension ;-)