### PR TITLE
Add exclusion for tables of type Setup for Rule LC0023

### DIFF
--- a/Design/Rule0023AlwaysSpecifyFieldgroups.cs
+++ b/Design/Rule0023AlwaysSpecifyFieldgroups.cs
@@ -21,10 +21,7 @@ namespace BusinessCentral.LinterCop.Design
             try
             {
                 ITableTypeSymbol table = (ITableTypeSymbol)ctx.Symbol;
-                if (table.Length > 0)
-                {
-                    if (IsTableOfTypeSetupTable(table.Fields[0])) return;
-                }
+                if (IsTableOfTypeSetupTable(table)) return;
 
                 Location FieldGroupLocation = table.GetLocation();
                 if (!table.Keys.IsEmpty)
@@ -46,10 +43,18 @@ namespace BusinessCentral.LinterCop.Design
             }
         }
 
-        private static bool IsTableOfTypeSetupTable(IFieldSymbol field)
+        private static bool IsTableOfTypeSetupTable(ITableTypeSymbol table)
         {
-            // The first field of the table should be of type Code and exactly (case sensitive) called 'Primary Key'
-            return (field.GetTypeSymbol().NavTypeKind == NavTypeKind.Code && field.Name == "Primary Key");
+            // Expect Primary Key to contains only one field
+            if (table.PrimaryKey.Fields.Length != 1) return (false);
+
+            // The field should be of type Code
+            if (table.PrimaryKey.Fields[0].GetTypeSymbol().GetNavTypeKindSafe() != NavTypeKind.Code) return (false);
+
+            // The field should be exactly (case sensitive) called 'Primary Key'
+            if (table.PrimaryKey.Fields[0].Name != "Primary Key") return (false);
+
+            return (true);
         }
     }
 }

--- a/Design/Rule0023AlwaysSpecifyFieldgroups.cs
+++ b/Design/Rule0023AlwaysSpecifyFieldgroups.cs
@@ -1,5 +1,6 @@
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Text;
 using System;
 using System.Collections.Immutable;
@@ -20,6 +21,10 @@ namespace BusinessCentral.LinterCop.Design
             try
             {
                 ITableTypeSymbol table = (ITableTypeSymbol)ctx.Symbol;
+                if (table.Length > 0)
+                {
+                    if (IsTableOfTypeSetupTable(table.Fields[0])) return;
+                }
 
                 Location FieldGroupLocation = table.GetLocation();
                 if (!table.Keys.IsEmpty)
@@ -39,6 +44,12 @@ namespace BusinessCentral.LinterCop.Design
             {
                 ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0000ErrorInRule, ctx.Symbol.GetLocation(), new Object[] { "Rule0023", "ArgumentOutOfRangeException", "" }));
             }
+        }
+
+        private static bool IsTableOfTypeSetupTable(IFieldSymbol field)
+        {
+            // The first field of the table should be of type Code and exactly (case sensitive) called 'Primary Key'
+            return (field.GetTypeSymbol().NavTypeKind == NavTypeKind.Code && field.Name == "Primary Key");
         }
     }
 }


### PR DESCRIPTION
This will resolve issue https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/241.

Because of the difficulty to determine if a table is a (Singleton) Setup table, I think the criteria should be;

* The first field of the Table should have the exact (case sensitive) name "Primary Key"
* The first field of the Table should be of type Code (can be Code[10], Code[20], the length can be different)