### PR TITLE
Improve enableRule0016ForApiObjects on LC0016

### DIFF
--- a/Design/Rule0016CheckForMissingCaptions.cs
+++ b/Design/Rule0016CheckForMissingCaptions.cs
@@ -49,7 +49,7 @@ namespace BusinessCentral.LinterCop.Design
                                         RaiseCaptionWarning(context);
                                 }
                             }
-                            break;
+                        break;
 
                     case ControlKind.Area:
                         break;


### PR DESCRIPTION
I found a issue on the enableRule0016ForApiObjects on the LC0016 rule and refactored this. I guess it wil also improve (a little bit) on performance.

@StefanMaron I could use your help on the IsPageTypeKindAPI function. Is there a better way to archive this (without the need of looping through the properties with a Foreach)

@dsaveyn, your remark [here](https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/190#issuecomment-1514752340) was on a already closed issue. In the future it will be a huge help for us if you could create a new issue, just to be sure it's not overlooked.