### PR TITLE
LC003 bugfix for false positive on objects with namespaces

### DIFF
--- a/Design/Rule0003DoNotUseObjectIDsInVariablesOrProperties.cs
+++ b/Design/Rule0003DoNotUseObjectIDsInVariablesOrProperties.cs
@@ -36,10 +36,10 @@ namespace BusinessCentral.LinterCop.Design
                 else
                     correctName = variable.Type.Name;
 
-                if (ctx.Node.ToString().Trim('"').ToUpper() != correctName.ToUpper())
+                if (ctx.Node.GetLastToken().ToString().Trim('"').ToUpper() != correctName.ToUpper())
                     ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0003DoNotUseObjectIDsInVariablesOrProperties, ctx.Node.GetLocation(), new object[] { ctx.Node.ToString().Trim('"'), correctName }));
 
-                if (ctx.Node.ToString().Trim('"') != correctName)
+                if (ctx.Node.GetLastToken().ToString().Trim('"') != correctName)
                     ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0005VariableCasingShouldNotDIfferFromDeclaration, ctx.Node.GetLocation(), new object[] { correctName, "" }));
             }
             if (ctx.ContainingSymbol.Kind == SymbolKind.Property)


### PR DESCRIPTION
This bugfix should restore the behaviour prior to the introduction of namespaces. Currently when you specify a full qualified object name the rule always triggers.
With runtime 12 a node can contain multiple tokens with namespaces but the last token in this context should always be the object name.