### PR TITLE
Suppress LC0025 when Access = Internal on object

### DIFF
--- a/Design/Rule0025InternalProcedureModifier.cs
+++ b/Design/Rule0025InternalProcedureModifier.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace BusinessCentral.LinterCop.Design
@@ -17,6 +17,8 @@ namespace BusinessCentral.LinterCop.Design
         {
             if (ctx.ContainingSymbol.IsObsoletePending || ctx.ContainingSymbol.IsObsoleteRemoved) return;
             if (ctx.ContainingSymbol.GetContainingObjectTypeSymbol().IsObsoletePending || ctx.ContainingSymbol.GetContainingObjectTypeSymbol().IsObsoleteRemoved) return;
+
+            if (ctx.ContainingSymbol.GetContainingObjectTypeSymbol().DeclaredAccessibility != Accessibility.Public) return;
 
             MethodDeclarationSyntax syntax = ctx.Node as MethodDeclarationSyntax;
             SyntaxNodeOrToken accessModifier = syntax.ProcedureKeyword.GetPreviousToken();


### PR DESCRIPTION
When access of the object itself is not public (aka Access = Internal), do not raise the LC0025 rule on the public methods.

```AL
codeunit 50100 "MyCodeunit"
{
    Access = Internal;

    procedure MyMethod();
    begin
    end;
}