### PR TITLE
Optimized LC0005

### DIFF
--- a/BusinessCentral.LinterCop.csproj
+++ b/BusinessCentral.LinterCop.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
Optimizations:

- String comparisons removed where possible
- Used ``ReadOnlySpan<char>`` instead of ``string`` where possible
- Generate a list of possible enums/strings at initialization of the analyzer and not every time the analyzer functions are called
- Array allocations removed where possible
- Removed duplicate ToString() calls where possible
- ``IsValidKind`` now generates all valid kinds once at startup and then uses the HashSet<SyntaxKind> to check if the kind is valid (lookup with Contains in a HashSet should be ``O(1)`` or at least better than string operations on every node/syntaxtoken)

Timings on a 914 files test project:
| | Time (s)  |  %  | Analyzer (Related Diagnostics) |
| --- | ---- | --- | --- |
|Before  | 13,583 |  69 |     Variable Casing Should Not Differ From Declaration (LC0005)|
|After  | 1,113  | 13     | Variable Casing Should Not Differ From Declaration (LC0005)|

I had to update the project to .NET Standard 2.1 to use the Span types and some convenient memory extensions methods. 

Fixes #284 + #304