### PR TITLE
Add CaptionML in CaptionIsMissing check LC0016

### DIFF
--- a/Design/Rule0016CheckForMissingCaptions.cs
+++ b/Design/Rule0016CheckForMissingCaptions.cs
@@ -158,7 +158,7 @@ namespace BusinessCentral.LinterCop.Design
                 return false;
 
             if (Symbol.GetBooleanPropertyValue(PropertyKind.ShowCaption) != false)
-                if (Symbol.GetProperty(PropertyKind.Caption) == null && Symbol.GetProperty(PropertyKind.CaptionClass) == null)
+                if (Symbol.GetProperty(PropertyKind.Caption) == null && Symbol.GetProperty(PropertyKind.CaptionClass) == null && Symbol.GetProperty(PropertyKind.CaptionML) == null)
                     return true;
             return false;
         }


### PR DESCRIPTION
fixes #626 

Simple fix attempt by adding `CaptionML` in the `CaptionIsMissing` check.
As described in the issue if "allowing" `CaptionML` is not wanted since afaik it should not be used anymore, then maybe checking if the field is an extension of a field "owned" by the base object would be possible? (I have no idea how one would implement that tho)