### PR TITLE
Warn if eventsubscribers don't use var for parameters defined as var.

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0065.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0065.cs
@@ -1,0 +1,35 @@
+namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0065
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0065");
+    }
+
+    [Test]
+    [TestCase("1")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0065CheckEventSubscriberVarKeyword>();
+        fixture.HasDiagnostic(code, Rule0065CheckEventSubscriberVarKeyword.DiagnosticDescriptors.Rule0065EventSubscriberVarCheck.Id);
+    }
+
+    [Test]
+    [TestCase("1")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0065CheckEventSubscriberVarKeyword>();
+        fixture.NoDiagnosticAtMarker(code, Rule0065CheckEventSubscriberVarKeyword.DiagnosticDescriptors.Rule0065EventSubscriberVarCheck.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0065/HasDiagnostic/1.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0065/HasDiagnostic/1.al
@@ -6,7 +6,7 @@ codeunit 50000 MyCodeunit
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::MyCodeunit, MyProcedure, '', false, false)]
-    local procedure MyProcedure2([|MyTable|]: Record MyTable; var [|Mytable2|]: Record MyTable; [|MyTable3|]: Record MyTable)
+    local procedure MyProcedure2(var MyTable: Record MyTable; var Mytable2: Record MyTable; [|MyTable3|]: Record MyTable)
     begin
 
     end;

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0065/HasDiagnostic/1.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0065/HasDiagnostic/1.al
@@ -1,0 +1,27 @@
+codeunit 50000 MyCodeunit
+{
+    [IntegrationEvent(false, false)]
+    local procedure MyProcedure(var MyTable: Record MyTable; var MyTable3: Record MyTable; var MyTable2: Record MyTable)
+    begin
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::MyCodeunit, MyProcedure, '', false, false)]
+    local procedure MyProcedure2([|MyTable|]: Record MyTable; var [|Mytable2|]: Record MyTable; [|MyTable3|]: Record MyTable)
+    begin
+
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0065/NoDiagnostic/1.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0065/NoDiagnostic/1.al
@@ -1,0 +1,27 @@
+codeunit 50000 MyCodeunit
+{
+    [IntegrationEvent(false, false)]
+    local procedure MyProcedure(var MyTable: Record MyTable; mytable2: Record MyTable)
+    begin
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::MyCodeunit, MyProcedure, '', false, false)]
+    local procedure MyProcedure2(var [|MyTable|]: Record MyTable; MyTable2: Record MyTable)
+    begin
+
+    end;
+}
+
+table 50000 MyTable
+{
+    Caption = '', Locked = true;
+
+    fields
+    {
+        field(1; MyField; Integer)
+        {
+            Caption = '', Locked = true;
+            DataClassification = ToBeClassified;
+        }
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable enable
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 using System.Collections.Immutable;
 using System.Reflection;
 
-#nullable enable
 namespace BusinessCentral.LinterCop.Design
 {
     public delegate bool Filter(IGrouping<int, Rule0044AnalyzeTransferFields.Field> fieldGroup);
@@ -305,7 +305,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private Table GetTableWithFieldsByTableName(Compilation compilation, string tableName, Dictionary<string, TableExtensionSyntax>? tableExtensions = null)
         {
-            IApplicationObjectTypeSymbol tableSymbol = compilation.GetApplicationObjectTypeSymbolsByNameAcrossModules(SymbolKind.Table, tableName).FirstOrDefault();
+            IApplicationObjectTypeSymbol? tableSymbol = compilation.GetApplicationObjectTypeSymbolsByNameAcrossModules(SymbolKind.Table, tableName).FirstOrDefault();
 
             Table table = new Table(tableName);
 
@@ -337,7 +337,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private string? GetSourceTableByPageName(Compilation compilation, string pageName)
         {
-            IApplicationObjectTypeSymbol pageSymbol = compilation.GetApplicationObjectTypeSymbolsByNameAcrossModules(SymbolKind.Page, pageName).FirstOrDefault();
+            IApplicationObjectTypeSymbol? pageSymbol = compilation.GetApplicationObjectTypeSymbolsByNameAcrossModules(SymbolKind.Page, pageName).FirstOrDefault();
 
             if (pageSymbol != null)
             {

--- a/BusinessCentral.LinterCop/Design/Rule0060CheckEventSubscriberVarKeyword.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0060CheckEventSubscriberVarKeyword.cs
@@ -1,0 +1,85 @@
+#nullable enable
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis.InternalSyntax;
+
+namespace BusinessCentral.LinterCop.Design;
+
+[DiagnosticAnalyzer]
+public class Rule0060CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create<DiagnosticDescriptor>(DiagnosticDescriptors.Rule0060EventSubscriberVarCheck);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterSymbolAction(CheckForEventSubscriberVar, SymbolKind.Method);
+    }
+
+    private void CheckForEventSubscriberVar(SymbolAnalysisContext context)
+    {
+        var methodSymbol = (IMethodSymbol)context.Symbol;
+        var eventSubscriberAttribute = methodSymbol.Attributes
+            .FirstOrDefault(attr => attr.AttributeKind == AttributeKind.EventSubscriber);
+
+        if (eventSubscriberAttribute == null)
+        {
+            return;
+        }
+
+        var method = GetReferencedEventPublisherMethodSymbol(context, eventSubscriberAttribute);
+        if (method == null)
+        {
+            return;
+        }
+
+        var publisherParameters = method.Parameters;
+
+        foreach (var subscriberParameter in methodSymbol.Parameters)
+        {
+            var publisherParameter = publisherParameters.FirstOrDefault(p => p.Name.Equals(subscriberParameter.Name, StringComparison.OrdinalIgnoreCase));
+            if (publisherParameter == null)
+            {
+                continue;
+            }
+
+            if (publisherParameter.IsVar && !subscriberParameter.IsVar)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.Rule0060EventSubscriberVarCheck,
+                    subscriberParameter.GetLocation(),
+                    new object[] { subscriberParameter.Name}));
+            }
+        }
+    }
+
+    private static IMethodSymbol? GetReferencedEventPublisherMethodSymbol(SymbolAnalysisContext context, IAttributeSymbol eventSubscriberAttribute)
+    {
+        var applicationObject = eventSubscriberAttribute.GetReferencedApplicationObject();
+        if (applicationObject == null)
+        {
+            return null;
+        }
+
+        if (eventSubscriberAttribute.Arguments.Length < 3)
+        {
+            return null;
+        }
+        
+        var eventName = eventSubscriberAttribute.Arguments[2].ValueText; 
+        return applicationObject.GetFirstMethod(eventName, context.Compilation);
+    }
+
+    public static class DiagnosticDescriptors
+    {
+        public static readonly DiagnosticDescriptor Rule0060EventSubscriberVarCheck = new(
+            id: LinterCopAnalyzers.AnalyzerPrefix + "0060",
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0060EventSubscriberVarCheckTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0060EventSubscriberVarCheckFormat"),
+            category: "Design",
+            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description:  LinterCopAnalyzers.GetLocalizableString("Rule0060EventSubscriberVarCheckDescription"),
+            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0060");
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0065CheckEventSubscriberVarKeyword.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0065CheckEventSubscriberVarKeyword.cs
@@ -67,7 +67,13 @@ public class Rule0065CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
             return null;
         }
         
-        var eventName = eventSubscriberAttribute.Arguments[2].ValueText; 
+        var eventName = eventSubscriberAttribute.Arguments[2].ValueText;
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+        if (eventName == null) 
+        {
+            return null;
+        }
+        
         return applicationObject.GetFirstMethod(eventName, context.Compilation);
     }
 

--- a/BusinessCentral.LinterCop/Design/Rule0065CheckEventSubscriberVarKeyword.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0065CheckEventSubscriberVarKeyword.cs
@@ -7,10 +7,10 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.InternalSyntax;
 namespace BusinessCentral.LinterCop.Design;
 
 [DiagnosticAnalyzer]
-public class Rule0060CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
+public class Rule0065CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-        ImmutableArray.Create<DiagnosticDescriptor>(DiagnosticDescriptors.Rule0060EventSubscriberVarCheck);
+        ImmutableArray.Create<DiagnosticDescriptor>(DiagnosticDescriptors.Rule0065EventSubscriberVarCheck);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -47,7 +47,7 @@ public class Rule0060CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
             if (publisherParameter.IsVar && !subscriberParameter.IsVar)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
-                    DiagnosticDescriptors.Rule0060EventSubscriberVarCheck,
+                    DiagnosticDescriptors.Rule0065EventSubscriberVarCheck,
                     subscriberParameter.GetLocation(),
                     new object[] { subscriberParameter.Name}));
             }
@@ -73,13 +73,13 @@ public class Rule0060CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
 
     public static class DiagnosticDescriptors
     {
-        public static readonly DiagnosticDescriptor Rule0060EventSubscriberVarCheck = new(
-            id: LinterCopAnalyzers.AnalyzerPrefix + "0060",
-            title: LinterCopAnalyzers.GetLocalizableString("Rule0060EventSubscriberVarCheckTitle"),
-            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0060EventSubscriberVarCheckFormat"),
+        public static readonly DiagnosticDescriptor Rule0065EventSubscriberVarCheck = new(
+            id: LinterCopAnalyzers.AnalyzerPrefix + "0065",
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0065EventSubscriberVarCheckTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0065EventSubscriberVarCheckFormat"),
             category: "Design",
             defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
-            description:  LinterCopAnalyzers.GetLocalizableString("Rule0060EventSubscriberVarCheckDescription"),
-            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0060");
+            description:  LinterCopAnalyzers.GetLocalizableString("Rule0065EventSubscriberVarCheckDescription"),
+            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0065");
     }
 }

--- a/BusinessCentral.LinterCop/Extensions.cs
+++ b/BusinessCentral.LinterCop/Extensions.cs
@@ -43,5 +43,30 @@ namespace BusinessCentral.LinterCop
         symbol = symbolInfo.Symbol;
         return true;
     }
+    
+    internal static IMethodSymbol? GetFirstMethod(
+      this IApplicationObjectTypeSymbol applicationObject,
+      string memberName,
+      Compilation compilation)
+    {
+      foreach (ISymbol member in applicationObject.GetMembers(memberName))
+      {
+        if (member.Kind == SymbolKind.Method)
+          return (IMethodSymbol) member;
+      }
+      foreach (var extensionsAcrossModule in compilation.GetApplicationObjectExtensionTypeSymbolsAcrossModules(applicationObject))
+      {
+        foreach (var member in extensionsAcrossModule.GetMembers(memberName))
+        {
+          if (member.Kind == SymbolKind.Method)
+          {
+            IMethodSymbol firstMethod = (IMethodSymbol) member;
+            return firstMethod;
+          }
+        }
+      }
+      return null;
+    }
+
   }
 }

--- a/BusinessCentral.LinterCop/Extensions.cs
+++ b/BusinessCentral.LinterCop/Extensions.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable enable
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 
 namespace BusinessCentral.LinterCop
@@ -21,25 +21,25 @@ namespace BusinessCentral.LinterCop
 
     internal static bool IsValidCamelCase(this string str) => !string.IsNullOrEmpty(str) && Extensions.CamelCaseRegex.IsMatch(str);
 
-    internal static IdentifierNameSyntax GetIdentifierNameSyntax(
+    internal static IdentifierNameSyntax? GetIdentifierNameSyntax(
       this SyntaxNodeAnalysisContext context)
     {
         if (context.Node.IsKind(SyntaxKind.IdentifierName))
-        return (IdentifierNameSyntax) context.Node;
-        return !context.Node.IsKind(SyntaxKind.IdentifierNameOrEmpty) ? (IdentifierNameSyntax) null : ((IdentifierNameOrEmptySyntax) context.Node).IdentifierName;
+          return (IdentifierNameSyntax?) context.Node;
+        return !context.Node.IsKind(SyntaxKind.IdentifierNameOrEmpty) ? (IdentifierNameSyntax?) null : ((IdentifierNameOrEmptySyntax) context.Node).IdentifierName;
     }
 
     internal static bool TryGetSymbolFromIdentifier(
       SyntaxNodeAnalysisContext syntaxNodeAnalysisContext,
       IdentifierNameSyntax identifierName,
       SymbolKind symbolKind,
-      out ISymbol symbol)
+      out ISymbol? symbol)
     {
-        symbol = (ISymbol) null;
+        symbol = (ISymbol?) null;
         SymbolInfo symbolInfo = syntaxNodeAnalysisContext.SemanticModel.GetSymbolInfo((ExpressionSyntax) identifierName, new CancellationToken());
-        ISymbol symbol1 = symbolInfo.Symbol;
+        ISymbol? symbol1 = symbolInfo.Symbol;
         if ((symbol1 != null ? (symbol1.Kind != symbolKind ? 1 : 0) : 1) != 0)
-        return false;
+          return false;
         symbol = symbolInfo.Symbol;
         return true;
     }

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.Designer.cs
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.Designer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Resources;
 using System.Runtime.CompilerServices;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 
 namespace BusinessCentral.LinterCop
 {
@@ -40,5 +41,14 @@ namespace BusinessCentral.LinterCop
         internal static string AnalyzerPrefix => LinterCopAnalyzers.ResourceManager.GetString(nameof(AnalyzerPrefix), LinterCopAnalyzers.resourceCulture);
 
         internal static string Fix0021ConfirmImplementConfirmManagementMessage => LinterCopAnalyzers.ResourceManager.GetString("Fix0021ConfirmImplementConfirmManagementMessage", LinterCopAnalyzers.resourceCulture);
+
+        internal static LocalizableString GetLocalizableString(string nameOfLocalizableResource)
+        {
+            return new LocalizableResourceString(
+                nameOfLocalizableResource,
+                LinterCopAnalyzers.ResourceManager,
+                typeof(LinterCopAnalyzers)
+                );
+        }
     }
 }

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -690,4 +690,13 @@
   <data name="Rule0064UseTableFieldToolTipInsteadOfPageFieldToolTipDescription" xml:space="preserve">
     <value>Use table field ToolTip instead of page field ToolTip.</value>
   </data>
+  <data name="Rule0060EventSubscriberVarCheckTitle" xml:space="preserve">
+    <value>Event subscriber var keyword mismatch</value>
+  </data>
+  <data name="Rule0060EventSubscriberVarCheckFormat" xml:space="preserve">
+    <value>Parameter '{0}' must use the 'var' keyword if the publisher parameter is 'var'.</value>
+  </data>
+  <data name="Rule0060EventSubscriberVarCheckDescription" xml:space="preserve">
+    <value>Ensures that event subscriber methods use 'var' keyword for parameters as defined by event publisher.</value>
+  </data>
 </root>

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -690,13 +690,13 @@
   <data name="Rule0064UseTableFieldToolTipInsteadOfPageFieldToolTipDescription" xml:space="preserve">
     <value>Use table field ToolTip instead of page field ToolTip.</value>
   </data>
-  <data name="Rule0060EventSubscriberVarCheckTitle" xml:space="preserve">
+  <data name="Rule0065EventSubscriberVarCheckTitle" xml:space="preserve">
     <value>Event subscriber var keyword mismatch</value>
   </data>
-  <data name="Rule0060EventSubscriberVarCheckFormat" xml:space="preserve">
+  <data name="Rule0065EventSubscriberVarCheckFormat" xml:space="preserve">
     <value>Parameter '{0}' must use the 'var' keyword if the publisher parameter is 'var'.</value>
   </data>
-  <data name="Rule0060EventSubscriberVarCheckDescription" xml:space="preserve">
+  <data name="Rule0065EventSubscriberVarCheckDescription" xml:space="preserve">
     <value>Ensures that event subscriber methods use 'var' keyword for parameters as defined by event publisher.</value>
   </data>
 </root>


### PR DESCRIPTION
This implements the idea from #654 and adds tests for the rule.

I also did some additional things:

- Fixed a NullReferenceException from Rule0054 that I was getting even with the fix from #673.
- I tried a new way to add the DiagnosticDescriptors. For this rule the Descriptors is now in a nested class inside the rule itself.
The reason for this is, that I find the ``LinterCopAnalyzers.Generated.cs`` file very unclear and unreadable with these extreme long lines.
- Fixed some Nullable warnings

I am open to suggestions, vetoes, or requests to split these changes into multiple PRs.