### PR TITLE
Fix boolean conversion for Rule0032

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0032ClearCodeunitSingleInstance.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0032ClearCodeunitSingleInstance.cs
@@ -74,14 +74,33 @@ namespace BusinessCentral.LinterCop.Design
 
         private static bool IsSingleInstanceCodeunitWithGlobalVars(ICodeunitTypeSymbol codeunitTypeSymbol)
         {
-            IPropertySymbol singleInstanceProperty = codeunitTypeSymbol.GetProperty(PropertyKind.SingleInstance);
-            if (singleInstanceProperty == null || !(bool)singleInstanceProperty.Value) return false;
+            if (!IsSingleInstanceCodeunit(codeunitTypeSymbol))
+            {
+                return false;
+            }
 
             var globalVariables = codeunitTypeSymbol.GetMembers().Where(members => members.Kind == SymbolKind.GlobalVariable);
             var globalVariablesNonRecordTypes = globalVariables.Where(vars => vars.GetTypeSymbol().GetNavTypeKindSafe() != NavTypeKind.Record);
 
             bool globalVariablesExists = globalVariablesNonRecordTypes.Count() != 0;
             return globalVariablesExists;
+        }
+
+        private static bool IsSingleInstanceCodeunit(ICodeunitTypeSymbol codeunitTypeSymbol)
+        {
+            IPropertySymbol singleInstanceProperty = codeunitTypeSymbol.GetProperty(PropertyKind.SingleInstance);
+            if (singleInstanceProperty == null)
+            {
+                return false;
+            }
+
+            // codeunits without source code could return "1" for the SingleInstance value
+            if (singleInstanceProperty.Value is not bool booleanValue)
+            {
+                return false;
+            }
+
+            return booleanValue;
         }
     }
 }


### PR DESCRIPTION
This is a partial fix for issue #523. It is only partial, because it prevents the exception, but the rule (still) can not detect problems with codeunits, that are only available as symbol/app and not as source code. 

The reason for the previous exception:
``singleInstanceProperty.Value`` return "1" if the codeunit has ``SingleInstance = true`` set and is references via app/symbol.

The reason why it is not fully fixable:
The ``codeunitTypeSymbol.GetMembers()`` call does not return global variables for codeunits that are only available as symbol/app and not in "real" source code. We are only getting procedures and triggers. Here a example:

```al
codeunit 54104 MyCodeunit
{
    var
        LogInManagement: Codeunit LogInManagement;

    procedure DoSomething()
    begin
        // This will not trigger the Rule0032 as GetMembers() does not work for
        // codeunits that are referenced by app/symbols and not by source code.
        ClearAll(); 
    end;
}
```

I tried to mitigate this problem by accessing internal methods (like the ``GlobalVariables`` property of ``ReferenceCodeunitTypeSymbol``) via reflection, but decided against it since I would have needed even more reflection to cast the return types correctly.

Fixes #523