### PR TITLE
Mark tests as parallelizable on assembly level

### DIFF
--- a/BusinessCentral.LinterCop.Test/AssemblyAttribute.cs
+++ b/BusinessCentral.LinterCop.Test/AssemblyAttribute.cs
@@ -1,0 +1,1 @@
+[assembly: NUnit.Framework.Parallelizable(ParallelScope.All)]


### PR DESCRIPTION
This will mark all tests as parallelizable

Shamelessly copied from https://docs.nunit.org/articles/nunit/writing-tests/attributes/parallelizable.html:
> The ParallelizableAttribute may be specified on multiple levels of the tests. Settings at a higher level may affect lower level tests, unless those lower-level tests override the inherited settings.

This will improvement test run time from like ~30-40 seconds to ~7 seconds.