### PR TITLE
Revert back to old static way of determining supported runtime

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
@@ -31,7 +31,7 @@ namespace BusinessCentral.LinterCop.Design
             if (manifest.Application == null && manifest.Platform == null) return;
 
             GetTargetProperty(manifest, out string propertyName, out Version propertyVersion);
-            ReleaseVersion.LatestSupportedRuntimeVersions.TryGetValue(propertyVersion, out Version supportedRuntime);
+            Version supportedRuntime = FindValueOfFirstValueLessThan(GetSupportedRuntimeVersions(), propertyVersion);
             if (supportedRuntime == null) return;
 
             if (manifest.Runtime < supportedRuntime)
@@ -50,6 +50,48 @@ namespace BusinessCentral.LinterCop.Design
                 propertyName = "platform";
                 propertyVersion = new Version(manifest.Platform.Major, manifest.Platform.Minor);
             }
+        }
+
+        private static SortedList<Version, Version> GetSupportedRuntimeVersions()
+        {
+            // Populate a SortedList with platform version and runtime version combined
+            SortedList<Version, Version> AvailableRuntimeVersion = new SortedList<Version, Version>();
+
+            // https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-choosing-runtime#currently-available-runtime-versions  
+            // When in the future the offset between the platform and runtime versions isn't exactly is eleven, we're in trouble
+            // By populating a list here, in stead of just adding up eleven somewhere else, we probably can resolve this here
+            int offset = 11;
+
+            foreach (var v in RuntimeVersion.SupportedVersions)
+            {
+                AvailableRuntimeVersion.Add(new Version(v.Major + offset, v.Minor), new Version(v.Major, v.Minor));
+            }
+            return AvailableRuntimeVersion;
+        }
+
+        private static Version FindValueOfFirstValueLessThan(SortedList<Version, Version> sortedList, Version version)
+        {
+            int index = FindIndexOfFirstValueLessThan(sortedList.Keys.ToList(), version);
+            return sortedList.ElementAtOrDefault(index).Value;
+        }
+
+        private static int FindIndexOfFirstValueLessThan<T>(List<T> sortedList, T value, IComparer<T> comparer = null)
+        {
+            var index = sortedList.BinarySearch(value, comparer);
+
+            // The value was found in the list. Just return its index.
+            if (index >= 0)
+                return index;
+
+            // The value was not found and "~index" is the index of the next value greater than the search value.
+            index = ~index;
+
+            // There are values in the list less than the search value. Return the index of the closest one.
+            if (index > 0)
+                return index - 1;
+
+            // All values in the list are greater than the search value.
+            return -1;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/668