### PR TITLE
Fixed reference to the diagnostic descriptor

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0027.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0027.cs
@@ -31,6 +31,6 @@ public class Rule0027
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0027RunPageImplementPageManagement>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0027RunPageImplementPageManagement.Id);
+        fixture.NoDiagnosticAtMarker(code, Rule0027RunPageImplementPageManagement.DiagnosticDescriptors.Rule0027RunPageImplementPageManagement.Id);
     }
 }


### PR DESCRIPTION
The test project cannot currently be built because a diagnostic descriptor has been refactored.

This PR fixes the test.

PS: Maybe we should introduce a solution file, so that refactoring like renaming is done automatically in the test project, too?