### PR TITLE
Exclude record objects outside the extensions in table(extension) obj…

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -116,6 +116,11 @@ namespace BusinessCentral.LinterCop.Design
 
             ITableTypeSymbol targetTable = (ITableTypeSymbol)((IRecordTypeSymbol)variableType).OriginalDefinition;
 
+            // Exclude record objects outside the extensions in table(extension) objects
+            if (!targetTable.GetLocation().IsInSource)
+                if (ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol()?.GetNavTypeKindSafe() == NavTypeKind.Table || ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol()?.GetNavTypeKindSafe() == NavTypeKind.TableExtension)
+                    return;
+
             if (ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol()?.NavTypeKind == NavTypeKind.Page)
             {
                 IPropertySymbol? sourceTableProperty = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol()?.GetProperty(PropertyKind.SourceTable);


### PR DESCRIPTION
Fixes https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/763

I have no idea on howto create a test case for this to have a object (record) where the property ```IsInSource```returns false.