### PR TITLE
Enable nullable in project

### DIFF
--- a/BusinessCentral.LinterCop/BusinessCentral.LinterCop.csproj
+++ b/BusinessCentral.LinterCop/BusinessCentral.LinterCop.csproj
@@ -6,6 +6,7 @@
         <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <Nullable>enable</Nullable>
+        <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
         <DefineConstants>$(DefineConstants)$(FeatureFlags.Replace("#",";"))</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/BusinessCentral.LinterCop/BusinessCentral.LinterCop.csproj
+++ b/BusinessCentral.LinterCop/BusinessCentral.LinterCop.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>Latest</LangVersion>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <Nullable>enable</Nullable>
         <DefineConstants>$(DefineConstants)$(FeatureFlags.Replace("#",";"))</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/BusinessCentral.LinterCop/Design/Rule0001FlowFieldsShouldNotBeEditable.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0001FlowFieldsShouldNotBeEditable.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0002CommitMustBeExplainedByComment.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0002CommitMustBeExplainedByComment.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;

--- a/BusinessCentral.LinterCop/Design/Rule0003DoNotUseObjectIDsInVariablesOrProperties.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0003DoNotUseObjectIDsInVariablesOrProperties.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;

--- a/BusinessCentral.LinterCop/Design/Rule0004LookupPageIdAndDrillDownPageId.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0004LookupPageIdAndDrillDownPageId.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;

--- a/BusinessCentral.LinterCop/Design/Rule0005VariableCasingShouldNotDifferFromDeclaration.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0005VariableCasingShouldNotDifferFromDeclaration.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;

--- a/BusinessCentral.LinterCop/Design/Rule0006FieldNotAutoIncrementInTemporaryTable.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0006FieldNotAutoIncrementInTemporaryTable.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0007DataPerCompanyShouldAlwaysBeSet.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0007DataPerCompanyShouldAlwaysBeSet.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0008NoFilterOperatorsInSetRange.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0008NoFilterOperatorsInSetRange.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;

--- a/BusinessCentral.LinterCop/Design/Rule0009CodeMetrics.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0009CodeMetrics.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0011AccessPropertyShouldAlwaysBeSet.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0011AccessPropertyShouldAlwaysBeSet.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.Helpers;

--- a/BusinessCentral.LinterCop/Design/Rule0012DoNotUseObjectIdInSystemFunctions.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0012DoNotUseObjectIdInSystemFunctions.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;

--- a/BusinessCentral.LinterCop/Design/Rule0014PermissionSetCaptionLength.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0014PermissionSetCaptionLength.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0015PermissionSetCoverage.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0015PermissionSetCoverage.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 using Microsoft.Dynamics.Nav.Analyzers.Common;

--- a/BusinessCentral.LinterCop/Design/Rule0016CheckForMissingCaptions.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0016CheckForMissingCaptions.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using BusinessCentral.LinterCop.Helpers;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0017WriteToFlowField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0017WriteToFlowField.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Semantics;

--- a/BusinessCentral.LinterCop/Design/Rule0018NoEventsInInternalCodeunits.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0018NoEventsInInternalCodeunits.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.InternalSyntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;

--- a/BusinessCentral.LinterCop/Design/Rule0019DataClassificationFieldEqualsTable.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0019DataClassificationFieldEqualsTable.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 

--- a/BusinessCentral.LinterCop/Design/Rule0020ApplicationAreaEqualsToPage.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0020ApplicationAreaEqualsToPage.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
 

--- a/BusinessCentral.LinterCop/Design/Rule0021BuiltInMethodImplementThroughCodeunit.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0021BuiltInMethodImplementThroughCodeunit.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0023AlwaysSpecifyFieldgroups.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0023AlwaysSpecifyFieldgroups.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0024SemicolonAfterProcedureDeclaration.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0024SemicolonAfterProcedureDeclaration.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
@@ -19,7 +20,7 @@ namespace BusinessCentral.LinterCop.Design
 
             MethodOrTriggerDeclarationSyntax syntax = ctx.Node as MethodOrTriggerDeclarationSyntax;
             if (syntax == null) return;
-            
+
             if (syntax.SemicolonToken.Kind != SyntaxKind.None)
             {
                 ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0024SemicolonAfterMethodOrTriggerDeclaration, syntax.SemicolonToken.GetLocation()));

--- a/BusinessCentral.LinterCop/Design/Rule0025InternalProcedureModifier.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0025InternalProcedureModifier.cs
@@ -1,4 +1,5 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
@@ -19,11 +20,11 @@ namespace BusinessCentral.LinterCop.Design
             if (ctx.IsObsoletePendingOrRemoved()) return;
 
             if (ctx.ContainingSymbol.GetContainingObjectTypeSymbol().DeclaredAccessibility != Accessibility.Public) return;
-            if (!ctx.Node.IsKind(SyntaxKind.MethodDeclaration)) return; 
-            
+            if (!ctx.Node.IsKind(SyntaxKind.MethodDeclaration)) return;
+
             try
             {
-                MethodDeclarationSyntax methodDeclarationSyntax = (MethodDeclarationSyntax)ctx.Node;            
+                MethodDeclarationSyntax methodDeclarationSyntax = (MethodDeclarationSyntax)ctx.Node;
                 SyntaxNodeOrToken accessModifier = methodDeclarationSyntax.ProcedureKeyword.GetPreviousToken();
                 if (accessModifier.Kind == SyntaxKind.LocalKeyword || accessModifier.Kind == SyntaxKind.InternalKeyword) return;
                 if (methodDeclarationSyntax.GetLeadingTrivia().Where(x => x.Kind == SyntaxKind.SingleLineDocumentationCommentTrivia).Any()) return;

--- a/BusinessCentral.LinterCop/Design/Rule0026ToolTipPunctuation.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0026ToolTipPunctuation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0027RunPageImplementPageManagement.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0027RunPageImplementPageManagement.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0028IdentifiersInEventSubscribers.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0028IdentifiersInEventSubscribers.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0029CompareDateTimeThroughCodeunit.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0029CompareDateTimeThroughCodeunit.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0030AccessInternalForInstallOrUpgradeCodeunits.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0030AccessInternalForInstallOrUpgradeCodeunits.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0031RecordInstanceIsolationLevel.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0031RecordInstanceIsolationLevel.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0032ClearCodeunitSingleInstance.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0032ClearCodeunitSingleInstance.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;

--- a/BusinessCentral.LinterCop/Design/Rule0034ExtensiblePropertyShouldAlwaysBeSet.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0034ExtensiblePropertyShouldAlwaysBeSet.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
@@ -1,5 +1,4 @@
 #if Fall2023RV1
-#nullable enable
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
@@ -41,7 +41,7 @@ namespace BusinessCentral.LinterCop.Design
                 if (ctx.Symbol.GetTypeSymbol().Kind != SymbolKind.TableExtension)
                     return;
                 ITableExtensionTypeSymbol tableExtension = (ITableExtensionTypeSymbol)ctx.Symbol;
-                if (!LookupOrDrillDownPageIsSet((ITableTypeSymbol)tableExtension.Target))
+                if (tableExtension.Target is not null && !LookupOrDrillDownPageIsSet((ITableTypeSymbol)tableExtension.Target))
                     return;
                 // allows diagnostic for table extension fields where base table has lookup or drilldown page set
                 // even if no relatedPages exist directly
@@ -141,11 +141,8 @@ namespace BusinessCentral.LinterCop.Design
             }
         }
 
-        private static bool LookupOrDrillDownPageIsSet(ITableTypeSymbol? table)
+        private static bool LookupOrDrillDownPageIsSet(ITableTypeSymbol table)
         {
-            if (table is null)
-                return false;
-
             return table.Properties.Any(e => e.PropertyKind == PropertyKind.DrillDownPageId || e.PropertyKind == PropertyKind.LookupPageId);
         }
     }

--- a/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0040ExplicitlySetRunTrigger.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0040ExplicitlySetRunTrigger.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0042AutoCalcFieldsOnNormalFields.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0042AutoCalcFieldsOnNormalFields.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 #if Fall2023RV1
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;

--- a/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;

--- a/BusinessCentral.LinterCop/Design/Rule0045ZeroEnumValueReservedForEmpty.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0045ZeroEnumValueReservedForEmpty.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0046LockedTokLabels.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0046LockedTokLabels.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0048ErrorWithTextConstant.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0048ErrorWithTextConstant.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0050OperatorAndPlaceholderInFilterExpression.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0050OperatorAndPlaceholderInFilterExpression.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 #if Fall2023RV1
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.Helpers;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0054FollowInterfaceObjectNameGuide.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0054FollowInterfaceObjectNameGuide.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0055TokSuffixForTokenLabels.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0055TokSuffixForTokenLabels.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0056AccessibilityEnumValueWithCaption.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0056AccessibilityEnumValueWithCaption.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0060RemovePropertyApplicationAreaOnApiPage.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0060RemovePropertyApplicationAreaOnApiPage.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0061SetODataKeyFieldsWithSystemIdField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0061SetODataKeyFieldsWithSystemIdField.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0062MandatoryFieldMissingOnApiPage.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0062MandatoryFieldMissingOnApiPage.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0063GiveFieldMoreDescriptiveName.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0063GiveFieldMoreDescriptiveName.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
@@ -1,3 +1,4 @@
+#nullable disable // TODO: Enable nullable and review rule
 #if Spring2024OrGreater
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/BusinessCentral.LinterCop/Design/Rule0065CheckEventSubscriberVarKeyword.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0065CheckEventSubscriberVarKeyword.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
@@ -49,7 +48,7 @@ public class Rule0065CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
                 context.ReportDiagnostic(Diagnostic.Create(
                     DiagnosticDescriptors.Rule0065EventSubscriberVarCheck,
                     subscriberParameter.GetLocation(),
-                    new object[] { subscriberParameter.Name}));
+                    new object[] { subscriberParameter.Name }));
             }
         }
     }
@@ -66,14 +65,14 @@ public class Rule0065CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
         {
             return null;
         }
-        
+
         var eventName = eventSubscriberAttribute.Arguments[2].ValueText;
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-        if (eventName == null) 
+        if (eventName == null)
         {
             return null;
         }
-        
+
         return applicationObject.GetFirstMethod(eventName, context.Compilation);
     }
 
@@ -85,7 +84,7 @@ public class Rule0065CheckEventSubscriberVarKeyword : DiagnosticAnalyzer
             messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0065EventSubscriberVarCheckFormat"),
             category: "Design",
             defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
-            description:  LinterCopAnalyzers.GetLocalizableString("Rule0065EventSubscriberVarCheckDescription"),
+            description: LinterCopAnalyzers.GetLocalizableString("Rule0065EventSubscriberVarCheckDescription"),
             helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0065");
     }
 }

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -178,7 +178,7 @@ namespace BusinessCentral.LinterCop.Design
                 var objectName = typeParts[1].Trim().Trim('"');
                 if (objectName.ToLowerInvariant() != variableType.Name.ToLowerInvariant())
 #if Fall2023RV1
-                    if (objectName.UnquoteIdentifier().ToLowerInvariant() != (variableType.OriginalDefinition.ContainingNamespace.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant())) 
+                    if (objectName.UnquoteIdentifier().ToLowerInvariant() != (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant())) 
 #endif
                     continue;
 
@@ -228,7 +228,7 @@ namespace BusinessCentral.LinterCop.Design
 
                 bool nameSpaceNameMatch = false;
 #if Fall2023RV1
-                nameSpaceNameMatch  = objectName.UnquoteIdentifier() == (variableType.OriginalDefinition.ContainingNamespace.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant());
+                nameSpaceNameMatch = objectName.UnquoteIdentifier() == (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant());
 #endif
 
                 // Match against the parameters of the procedure

--- a/BusinessCentral.LinterCop/Design/Rule0069EmptyStatements.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0069EmptyStatements.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0070ListObjectsAreOneBased.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0070ListObjectsAreOneBased.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
+++ b/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Microsoft.Dynamics.Nav.CodeAnalysis;
 
-namespace BusinessCentral.LinterCop.Helpers {
-    public class HelperFunctions {
+namespace BusinessCentral.LinterCop.Helpers
+{
+    public class HelperFunctions
+    {
         public static bool MethodImplementsInterfaceMethod(IMethodSymbol methodSymbol)
         {
             return MethodImplementsInterfaceMethod(methodSymbol.GetContainingApplicationObjectTypeSymbol(), methodSymbol);

--- a/BusinessCentral.LinterCop/Helpers/LinterSettings.cs
+++ b/BusinessCentral.LinterCop/Helpers/LinterSettings.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿#nullable disable // TODO: Enable nullable and review rule
+using Newtonsoft.Json;
 
 namespace BusinessCentral.LinterCop.Helpers
 {


### PR DESCRIPTION
Enabling nullable reference types will improve the LinterCop on reducing possible `System.NullReferenceException` errors.

New rules will automatically have the nullable reference types enabled, where existing rules will be reviewed in the future.

> Originally, all reference-type variables were nullable. This meant that you always had to consider the possibility of a null reference and code accordingly. If it was your intention that a variable never be null, there was no way to enforce that. If you treated it like it would never be null, there was always the possibility of a NullReferenceException at run time if someone mistakenly set it to null.
> 
> Now, you can specify which variables should be nullable and which shouldn't and the compiler will enforce that. If you try to make a non-nullable variable null, a compiler error will prevent that. If you treat a nullable variable as though it definitely won't be null, a compiler warning will alert you.

https://stackoverflow.com/a/74583086


