### PR TITLE
Comments for LC0069 instead of special cases

### DIFF
--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0069/NoDiagnostic/3.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0069/NoDiagnostic/3.al
@@ -1,9 +1,10 @@
-﻿codeunit 50100 MyCodeunit
+﻿// testcase for a normal assignment with semicolon (not an empty statement)
+codeunit 50100 MyCodeunit
 {
     procedure MyProcedure(Param: Boolean)
     var
         LocalVar: Boolean;
     begin
-        LocalVar := Param[|;|] // just a normal assignment with semicolon (not an empty statement)
+        LocalVar := Param[|;|]
     end;
 }

--- a/BusinessCentral.LinterCop/Design/Rule0069EmptyStatements.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0069EmptyStatements.cs
@@ -2,6 +2,7 @@
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using System.Collections.Immutable;
 
 namespace BusinessCentral.LinterCop.Design
@@ -17,8 +18,13 @@ namespace BusinessCentral.LinterCop.Design
         {
             if (ctx.IsObsoletePendingOrRemoved()) return;
 
-            // exclude empty ifs (runtime error guard) and empty case lines
-            if (ctx.Operation.Syntax.Parent.IsKind(SyntaxKind.IfStatement) || ctx.Operation.Syntax.Parent.IsKind(SyntaxKind.CaseLine)) return;
+            foreach (SyntaxTrivia trivia in ctx.Operation.Syntax.Parent.GetLeadingTrivia())
+                if (trivia.IsKind(SyntaxKind.LineCommentTrivia))
+                    return;
+
+            foreach (SyntaxTrivia trivia in ctx.Operation.Syntax.Parent.GetTrailingTrivia())
+                if (trivia.IsKind(SyntaxKind.LineCommentTrivia))
+                    return;
 
             ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0069EmptyStatements, ctx.Operation.Syntax.GetLocation()));
         }

--- a/BusinessCentral.LinterCop/LinterCop.ruleset.json
+++ b/BusinessCentral.LinterCop/LinterCop.ruleset.json
@@ -345,7 +345,7 @@
     {
       "id": "LC0069",
       "action": "Info",
-      "justification": "Avoid empty statements."
+      "justification": "Empty statements should be avoided or should have a leading or trailing comment explaining their use."
     },
     {
       "id": "LC0070",

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -733,13 +733,13 @@
     <value>Informs the user that there are missing permission to access tabledata.</value>
   </data>
   <data name="Rule0069EmptyStatementsTitle" xml:space="preserve">
-    <value>Avoid empty statements.</value>
+    <value>Empty statements should be avoided or should have a leading or trailing comment explaining their use.</value>
   </data>
   <data name="Rule0069EmptyStatementsFormat" xml:space="preserve">
-    <value>Empty statements should be avoided.</value>
+    <value>Empty statements should be avoided or should have a leading or trailing comment explaining their use.</value>
   </data>
   <data name="Rule0069EmptyStatementsDescription" xml:space="preserve">
-    <value>Empty statements should be avoided.</value>
+    <value>Empty statements should be avoided or should have a leading or trailing comment explaining their use.</value>
   </data>
   <data name="Rule0070ListObjectsAreOneBasedTitle" xml:space="preserve">
     <value>Zero index access on 1-based List objects.</value>

--- a/README.md
+++ b/README.md
@@ -222,5 +222,5 @@ For an example and the default values see: [LinterCop.ruleset.json](LinterCop.ru
 |[LC0066](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0066)|Duplicate ToolTip between page and table field.|Info|
 |[LC0067](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0067)|Set `NotBlank` property to `false` when 'No. Series' TableRelation exists.|Warning|
 |[LC0068](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0068)|Informs the user that there are missing permission to access tabledata.|Info|
-|[LC0069](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0069)|Avoid empty statements.|Info|
+|[LC0069](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0069)|Empty statements should be avoided or should have a leading or trailing comment explaining their use.|Info|
 |[LC0070](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0070)|Zero index access on 1-based List objects.|Warning|


### PR DESCRIPTION
Fixes #747 

Replaces the special cases with a general check for comments (reused the LC0002 check).
I think this helps readability for the special cases too, since it can be a bit unclear what they do at first sight.
And it allows for any other "wanted" empty statements like in #747.

Wiki may need to be updated for the change to comments.