### PR TITLE
Exclude previous pre-release version of the AL Language

### DIFF
--- a/.github/actions/marketplace/Get-Marketplace.ps1
+++ b/.github/actions/marketplace/Get-Marketplace.ps1
@@ -19,8 +19,27 @@ $listing = Invoke-WebRequest -Method POST -UseBasicParsing `
     -Body '{"filters":[{"criteria":[{"filterType":4,"value":"fe889a8a-1498-4047-850d-eb8ea82de1d1"}],"pageNumber":1,"pageSize":50,"sortBy":0,"sortOrder":0}],"assetTypes":[],"flags":0x12}' `
     -ContentType application/json | ConvertFrom-Json
 
+# Filter out versions below v12
 $listingFiltered = $listing.results | Select-Object -First 1 -ExpandProperty extensions `
 | Select-Object -ExpandProperty versions `
 | Where-Object { $(ConvertTo-Version($_.version)) -gt [System.Version]::Parse("12.0.0") }
+
+# Find current release version
+$currentRelease = $listingFiltered `
+| Where-Object properties -ne $null `
+| Where-Object { $_.properties.key -notcontains 'Microsoft.VisualStudio.Code.PreRelease' } `
+| Select-Object -First 1 -ExpandProperty version
+
+# Remove pre-release versions lower than currentRelease
+$listingFiltered = $listingFiltered `
+| Where-Object { 
+    $version = ConvertTo-Version($_.version)
+    $preRelease = $_.properties | Where-Object { $_.key -eq 'Microsoft.VisualStudio.Code.PreRelease' }
+
+    if ($preRelease -and $version -lt (ConvertTo-Version $currentRelease)) {
+        return $false
+    }
+    return $true
+}
 
 Write-Output $listingFiltered | ConvertTo-Json -Compress -Depth 3


### PR DESCRIPTION
The cost of maintaining support for the previous **_pre_**-release versions of the AL Languages comes with a cost.

It's quite challenging to manage changes between the pre-release versions within a major release of the AL Language. This is _by design_ as pre-release versions can introduce breaking changes.

With this PR we're only going to build assets for pre-release versions of the upcoming AL Language version. Once a new official release is available, builds for any earlier pre-release versions will cease.