### PR TITLE
Improve support on legacy AL Language version

### DIFF
--- a/.github/actions/feature-flags/Get-FeatureFlags.ps1
+++ b/.github/actions/feature-flags/Get-FeatureFlags.ps1
@@ -29,30 +29,30 @@ function Get-FeatureFlags {
     $featureFlags = ""
 
     $RuntimeVersion = [Ordered]@{
-        'Spring2018OrLower'    = '1.0'
-        'Fall2018OrLower'      = '2.0'
-        'Spring2019OrLower'    = '3.0'
-        'Fall2019OrLower'      = '4.0'
-        'Spring2020OrLower'    = '5.0'
-        'Fall2020OrLower'      = '6.0'
-        'Spring2021OrLower'    = '7.0'
-        'Fall2021OrLower'      = '8.0'
-        'Spring2022OrLower'    = '9.0'
-        'Spring2022RV1OrLower' = '9.1'
-        'Spring2022RV2OrLower' = '9.2'
-        'Fall2022OrLower'      = '10.0'
-        'Spring2023OrLower'    = '11.0'
-        'Fall2023OrLower'      = '12.0'
-        'Fall2023RV1OrLower'   = '12.1'
-        'Fall2023RV2OrLower'   = '12.2'
-        'Fall2023RV3OrLower'   = '12.3'
-        'Spring2024OrLower'    = '13.0'
-        'Fall2024OrLower'      = '14.0'
-        'Spring2025OrLower'    = '15.0'
-        'Fall2025OrLower'      = '16.0'
+        'Spring2018'    = '1.0'
+        'Fall2018'      = '2.0'
+        'Spring2019'    = '3.0'
+        'Fall2019'      = '4.0'
+        'Spring2020'    = '5.0'
+        'Fall2020'      = '6.0'
+        'Spring2021'    = '7.0'
+        'Fall2021'      = '8.0'
+        'Spring2022'    = '9.0'
+        'Spring2022RV1' = '9.1'
+        'Spring2022RV2' = '9.2'
+        'Fall2022'      = '10.0'
+        'Spring2023'    = '11.0'
+        'Fall2023'      = '12.0'
+        'Fall2023RV1'   = '12.1'
+        'Fall2023RV2'   = '12.2'
+        'Fall2023RV3'   = '12.3'
+        'Spring2024'    = '13.0'
+        'Fall2024'      = '14.0'
+        'Spring2025'    = '15.0'
+        'Fall2025'      = '16.0'
     }
 
-    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -le $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
+    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -ge $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
     if (![string]::IsNullOrEmpty($supportedRuntimeVersions)) {
         $featureFlags = [System.String]::Join("", $supportedRuntimeVersions)
     }

--- a/.github/actions/feature-flags/Get-FeatureFlags.ps1
+++ b/.github/actions/feature-flags/Get-FeatureFlags.ps1
@@ -29,33 +29,30 @@ function Get-FeatureFlags {
     $featureFlags = ""
 
     $RuntimeVersion = [Ordered]@{
-        'Spring2018'       = '1.0'
-        'Fall2018'         = '2.0'
-        'Spring2019'       = '3.0'
-        'Fall2019'         = '4.0'
-        'Spring2020'       = '5.0'
-        'Fall2020'         = '6.0'
-        'Spring2021'       = '7.0'
-        'Fall2021'         = '8.0'
-        'Spring2022'       = '9.0'
-        'Spring2022RV1'    = '9.1'
-        'Spring2022RV2'    = '9.2'
-        'Fall2022'         = '10.0'
-        'Spring2023'       = '11.0'
-        'Fall2023'         = '12.0'
-        'Fall2023RV1'      = '12.1'
-        'Fall2023RV2'      = '12.2'
-        'Fall2023RV3'      = '12.3'
-        'Spring2024'       = '13.0'
-        'Fall2024'         = '14.0'
-        'Spring2025'       = '15.0'
-        'Fall2025'         = '16.0'
-
-        'ManifestHelper'   = '13.0.937154'
-        'PageSystemAction' = '13.0.878831'
+        'Spring2018'    = '1.0'
+        'Fall2018'      = '2.0'
+        'Spring2019'    = '3.0'
+        'Fall2019'      = '4.0'
+        'Spring2020'    = '5.0'
+        'Fall2020'      = '6.0'
+        'Spring2021'    = '7.0'
+        'Fall2021'      = '8.0'
+        'Spring2022'    = '9.0'
+        'Spring2022RV1' = '9.1'
+        'Spring2022RV2' = '9.2'
+        'Fall2022'      = '10.0'
+        'Spring2023'    = '11.0'
+        'Fall2023'      = '12.0'
+        'Fall2023RV1'   = '12.1'
+        'Fall2023RV2'   = '12.2'
+        'Fall2023RV3'   = '12.3'
+        'Spring2024'    = '13.0'
+        'Fall2024'      = '14.0'
+        'Spring2025'    = '15.0'
+        'Fall2025'      = '16.0'
     }
 
-    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -le $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
+    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -ge $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
     if (![string]::IsNullOrEmpty($supportedRuntimeVersions)) {
         $featureFlags = [System.String]::Join("", $supportedRuntimeVersions)
     }

--- a/.github/actions/feature-flags/Get-FeatureFlags.ps1
+++ b/.github/actions/feature-flags/Get-FeatureFlags.ps1
@@ -29,30 +29,30 @@ function Get-FeatureFlags {
     $featureFlags = ""
 
     $RuntimeVersion = [Ordered]@{
-        'Spring2018'    = '1.0'
-        'Fall2018'      = '2.0'
-        'Spring2019'    = '3.0'
-        'Fall2019'      = '4.0'
-        'Spring2020'    = '5.0'
-        'Fall2020'      = '6.0'
-        'Spring2021'    = '7.0'
-        'Fall2021'      = '8.0'
-        'Spring2022'    = '9.0'
-        'Spring2022RV1' = '9.1'
-        'Spring2022RV2' = '9.2'
-        'Fall2022'      = '10.0'
-        'Spring2023'    = '11.0'
-        'Fall2023'      = '12.0'
-        'Fall2023RV1'   = '12.1'
-        'Fall2023RV2'   = '12.2'
-        'Fall2023RV3'   = '12.3'
-        'Spring2024'    = '13.0'
-        'Fall2024'      = '14.0'
-        'Spring2025'    = '15.0'
-        'Fall2025'      = '16.0'
+        'Spring2018OrLower'    = '1.0'
+        'Fall2018OrLower'      = '2.0'
+        'Spring2019OrLower'    = '3.0'
+        'Fall2019OrLower'      = '4.0'
+        'Spring2020OrLower'    = '5.0'
+        'Fall2020OrLower'      = '6.0'
+        'Spring2021OrLower'    = '7.0'
+        'Fall2021OrLower'      = '8.0'
+        'Spring2022OrLower'    = '9.0'
+        'Spring2022RV1OrLower' = '9.1'
+        'Spring2022RV2OrLower' = '9.2'
+        'Fall2022OrLower'      = '10.0'
+        'Spring2023OrLower'    = '11.0'
+        'Fall2023OrLower'      = '12.0'
+        'Fall2023RV1OrLower'   = '12.1'
+        'Fall2023RV2OrLower'   = '12.2'
+        'Fall2023RV3OrLower'   = '12.3'
+        'Spring2024OrLower'    = '13.0'
+        'Fall2024OrLower'      = '14.0'
+        'Spring2025OrLower'    = '15.0'
+        'Fall2025OrLower'      = '16.0'
     }
 
-    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -ge $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
+    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -gt $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
     if (![string]::IsNullOrEmpty($supportedRuntimeVersions)) {
         $featureFlags = [System.String]::Join("", $supportedRuntimeVersions)
     }

--- a/.github/actions/feature-flags/Get-FeatureFlags.ps1
+++ b/.github/actions/feature-flags/Get-FeatureFlags.ps1
@@ -52,7 +52,7 @@ function Get-FeatureFlags {
         'Fall2025OrLower'      = '16.0'
     }
 
-    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -gt $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
+    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -le $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
     if (![string]::IsNullOrEmpty($supportedRuntimeVersions)) {
         $featureFlags = [System.String]::Join("", $supportedRuntimeVersions)
     }

--- a/.github/actions/feature-flags/Get-FeatureFlags.ps1
+++ b/.github/actions/feature-flags/Get-FeatureFlags.ps1
@@ -29,30 +29,30 @@ function Get-FeatureFlags {
     $featureFlags = ""
 
     $RuntimeVersion = [Ordered]@{
-        'Spring2018'    = '1.0'
-        'Fall2018'      = '2.0'
-        'Spring2019'    = '3.0'
-        'Fall2019'      = '4.0'
-        'Spring2020'    = '5.0'
-        'Fall2020'      = '6.0'
-        'Spring2021'    = '7.0'
-        'Fall2021'      = '8.0'
-        'Spring2022'    = '9.0'
-        'Spring2022RV1' = '9.1'
-        'Spring2022RV2' = '9.2'
-        'Fall2022'      = '10.0'
-        'Spring2023'    = '11.0'
-        'Fall2023'      = '12.0'
-        'Fall2023RV1'   = '12.1'
-        'Fall2023RV2'   = '12.2'
-        'Fall2023RV3'   = '12.3'
-        'Spring2024'    = '13.0'
-        'Fall2024'      = '14.0'
-        'Spring2025'    = '15.0'
-        'Fall2025'      = '16.0'
+        'LessThenSpring2018'    = '1.0'
+        'LessThenFall2018'      = '2.0'
+        'LessThenSpring2019'    = '3.0'
+        'LessThenFall2019'      = '4.0'
+        'LessThenSpring2020'    = '5.0'
+        'LessThenFall2020'      = '6.0'
+        'LessThenSpring2021'    = '7.0'
+        'LessThenFall2021'      = '8.0'
+        'LessThenSpring2022'    = '9.0'
+        'LessThenSpring2022RV1' = '9.1'
+        'LessThenSpring2022RV2' = '9.2'
+        'LessThenFall2022'      = '10.0'
+        'LessThenSpring2023'    = '11.0'
+        'LessThenFall2023'      = '12.0'
+        'LessThenFall2023RV1'   = '12.1'
+        'LessThenFall2023RV2'   = '12.2'
+        'LessThenFall2023RV3'   = '12.3'
+        'LessThenSpring2024'    = '13.0'
+        'LessThenFall2024'      = '14.0'
+        'LessThenSpring2025'    = '15.0'
+        'LessThenFall2025'      = '16.0'
     }
 
-    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -ge $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
+    $supportedRuntimeVersions = $RuntimeVersion.GetEnumerator() | Where-Object { $(ConvertTo-Version($_.Value)) -gt $(ConvertTo-Version($version)) } | Foreach-Object { $_.Key } | ForEach-Object { "#$_" }
     if (![string]::IsNullOrEmpty($supportedRuntimeVersions)) {
         $featureFlags = [System.String]::Join("", $supportedRuntimeVersions)
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
                 "${workspaceFolder}/BusinessCentral.LinterCop/BusinessCentral.LinterCop.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary",
-                "/p:FeatureFlags=#Spring2018#Fall2018#Spring2019#Fall2019#Spring2020#Fall2020#Spring2021#Fall2021#Spring2022#Spring2022RV1#Spring2022RV2#Fall2022#Spring2023#Fall2023#Fall2023RV1#Fall2023RV2#Fall2023RV3#Spring2024#Fall2024#ManifestHelper#PageSystemAction"
+                "/p:FeatureFlags="
             ],
             "group": "build",
             "problemMatcher": "$msCompile",

--- a/BusinessCentral.LinterCop.Test/BusinessCentral.LinterCop.Test.csproj
+++ b/BusinessCentral.LinterCop.Test/BusinessCentral.LinterCop.Test.csproj
@@ -7,6 +7,8 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <DefineConstants>$(DefineConstants)$(FeatureFlags.Replace("#",";"))</DefineConstants>
+
     </PropertyGroup>
 
     <ItemGroup>

--- a/BusinessCentral.LinterCop.Test/Rule0043.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0043.cs
@@ -1,4 +1,4 @@
-#if Spring2024
+#if !Spring2024
 namespace BusinessCentral.LinterCop.Test;
 
 public class Rule0043

--- a/BusinessCentral.LinterCop.Test/Rule0043.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0043.cs
@@ -1,4 +1,4 @@
-#if !Spring2024
+#if !Fall2023RV3OrLower
 namespace BusinessCentral.LinterCop.Test;
 
 public class Rule0043

--- a/BusinessCentral.LinterCop.Test/Rule0043.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0043.cs
@@ -1,4 +1,4 @@
-#if !Spring2024
+#if !LessThenSpring2024
 namespace BusinessCentral.LinterCop.Test;
 
 public class Rule0043

--- a/BusinessCentral.LinterCop.Test/Rule0043.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0043.cs
@@ -1,4 +1,4 @@
-#if !Fall2023RV3OrLower
+#if !Spring2024
 namespace BusinessCentral.LinterCop.Test;
 
 public class Rule0043

--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -36,7 +36,7 @@ public class Rule0068
     [TestCase("ProcedureCallsInherentPermissionsProperty")]
     [TestCase("ProcedureCallsInherentPermissionsAttribute")]
     [TestCase("PageSourceTable")]
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
     [TestCase("ProcedureCallsPermissionsPropertyFullyQualified")]
 #endif
     // [TestCase("IntegerTable")]

--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -36,7 +36,7 @@ public class Rule0068
     [TestCase("ProcedureCallsInherentPermissionsProperty")]
     [TestCase("ProcedureCallsInherentPermissionsAttribute")]
     [TestCase("PageSourceTable")]
-#if Fall2023RV1
+#if !Fall2023RV1
     [TestCase("ProcedureCallsPermissionsPropertyFullyQualified")]
 #endif
     // [TestCase("IntegerTable")]

--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -36,7 +36,7 @@ public class Rule0068
     [TestCase("ProcedureCallsInherentPermissionsProperty")]
     [TestCase("ProcedureCallsInherentPermissionsAttribute")]
     [TestCase("PageSourceTable")]
-#if !Fall2023RV1
+#if !Fall2023OrLower
     [TestCase("ProcedureCallsPermissionsPropertyFullyQualified")]
 #endif
     // [TestCase("IntegerTable")]

--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -36,7 +36,7 @@ public class Rule0068
     [TestCase("ProcedureCallsInherentPermissionsProperty")]
     [TestCase("ProcedureCallsInherentPermissionsAttribute")]
     [TestCase("PageSourceTable")]
-#if !Fall2023OrLower
+#if !Fall2023RV1
     [TestCase("ProcedureCallsPermissionsPropertyFullyQualified")]
 #endif
     // [TestCase("IntegerTable")]

--- a/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
@@ -57,7 +57,7 @@ public class Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys : DiagnosticAnalyz
         return table.Fields
             .Where(x => x.Id > 0 && x.Id < 2000000000)
             .Where(x => x.FieldClass == FieldClassKind.Normal)
-#if !Fall2024
+#if !LessThenFall2024
             .Where(x => x.Type.GetNavTypeKindSafe() == NavTypeKind.Code)
 #endif
             .Any(field =>

--- a/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
@@ -57,7 +57,7 @@ public class Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys : DiagnosticAnalyz
         return table.Fields
             .Where(x => x.Id > 0 && x.Id < 2000000000)
             .Where(x => x.FieldClass == FieldClassKind.Normal)
-#if !Fall2024
+#if !Spring2024OrLower
             .Where(x => x.Type.GetNavTypeKindSafe() == NavTypeKind.Code)
 #endif
             .Any(field =>

--- a/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
@@ -57,7 +57,7 @@ public class Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys : DiagnosticAnalyz
         return table.Fields
             .Where(x => x.Id > 0 && x.Id < 2000000000)
             .Where(x => x.FieldClass == FieldClassKind.Normal)
-#if !Spring2024OrLower
+#if !Fall2024
             .Where(x => x.Type.GetNavTypeKindSafe() == NavTypeKind.Code)
 #endif
             .Any(field =>

--- a/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.cs
@@ -57,7 +57,7 @@ public class Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys : DiagnosticAnalyz
         return table.Fields
             .Where(x => x.Id > 0 && x.Id < 2000000000)
             .Where(x => x.FieldClass == FieldClassKind.Normal)
-#if Fall2024
+#if !Fall2024
             .Where(x => x.Type.GetNavTypeKindSafe() == NavTypeKind.Code)
 #endif
             .Any(field =>

--- a/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
@@ -3,7 +3,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using System.Collections.Immutable;
-#if ManifestHelper
+#if !Spring2024
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -21,7 +21,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void CheckAppManifestRuntime(CompilationAnalysisContext ctx)
         {
-#if ManifestHelper
+#if !Spring2024
             NavAppManifest manifest = ManifestHelper.GetManifest(ctx.Compilation);
 #else
             NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(ctx.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
@@ -3,7 +3,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using System.Collections.Immutable;
-#if !Spring2024
+#if !LessThenSpring2024
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -21,7 +21,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void CheckAppManifestRuntime(CompilationAnalysisContext ctx)
         {
-#if !Spring2024
+#if !LessThenSpring2024
             NavAppManifest manifest = ManifestHelper.GetManifest(ctx.Compilation);
 #else
             NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(ctx.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
@@ -3,7 +3,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using System.Collections.Immutable;
-#if !Spring2024
+#if !Fall2023RV3OrLower
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -21,7 +21,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void CheckAppManifestRuntime(CompilationAnalysisContext ctx)
         {
-#if !Spring2024
+#if !Fall2023RV3OrLower
             NavAppManifest manifest = ManifestHelper.GetManifest(ctx.Compilation);
 #else
             NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(ctx.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0033AppManifestRuntimeBehind.cs
@@ -3,7 +3,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using System.Collections.Immutable;
-#if !Fall2023RV3OrLower
+#if !Spring2024
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -21,7 +21,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void CheckAppManifestRuntime(CompilationAnalysisContext ctx)
         {
-#if !Fall2023RV3OrLower
+#if !Spring2024
             NavAppManifest manifest = ManifestHelper.GetManifest(ctx.Compilation);
 #else
             NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(ctx.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
@@ -1,4 +1,4 @@
-#if !Fall2023OrLower
+#if !Fall2023RV1
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
@@ -1,4 +1,4 @@
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
@@ -1,4 +1,4 @@
-#if Fall2023RV1
+#if !Fall2023RV1
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0035ExplicitSetAllowInCustomizations.cs
@@ -1,4 +1,4 @@
-#if !Fall2023RV1
+#if !Fall2023OrLower
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
@@ -137,7 +137,7 @@ namespace BusinessCentral.LinterCop.Design
         private static bool AreTheSameNavObjects(ITableTypeSymbol left, ITableTypeSymbol right)
         {
             if (left.GetNavTypeKindSafe() != right.GetNavTypeKindSafe()) return false;
-#if !Fall2023RV1
+#if !Fall2023OrLower
             if (((INamespaceSymbol)left.ContainingSymbol).QualifiedName != ((INamespaceSymbol)right.ContainingSymbol).QualifiedName) return false;
 #endif
             if (left.Name != right.Name) return false;
@@ -146,7 +146,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private static string GetFullyQualifiedObjectName(IPageTypeSymbol page)
         {
-#if !Fall2023RV1
+#if !Fall2023OrLower
             if (page.ContainingNamespace.QualifiedName != "")
                 return page.ContainingNamespace.QualifiedName + "." + page.Name.QuoteIdentifierIfNeeded();
 #endif

--- a/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
@@ -137,7 +137,7 @@ namespace BusinessCentral.LinterCop.Design
         private static bool AreTheSameNavObjects(ITableTypeSymbol left, ITableTypeSymbol right)
         {
             if (left.GetNavTypeKindSafe() != right.GetNavTypeKindSafe()) return false;
-#if Fall2023RV1
+#if !Fall2023RV1
             if (((INamespaceSymbol)left.ContainingSymbol).QualifiedName != ((INamespaceSymbol)right.ContainingSymbol).QualifiedName) return false;
 #endif
             if (left.Name != right.Name) return false;
@@ -146,7 +146,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private static string GetFullyQualifiedObjectName(IPageTypeSymbol page)
         {
-#if Fall2023RV1
+#if !Fall2023RV1
             if (page.ContainingNamespace.QualifiedName != "")
                 return page.ContainingNamespace.QualifiedName + "." + page.Name.QuoteIdentifierIfNeeded();
 #endif

--- a/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
@@ -137,7 +137,7 @@ namespace BusinessCentral.LinterCop.Design
         private static bool AreTheSameNavObjects(ITableTypeSymbol left, ITableTypeSymbol right)
         {
             if (left.GetNavTypeKindSafe() != right.GetNavTypeKindSafe()) return false;
-#if !Fall2023OrLower
+#if !Fall2023RV1
             if (((INamespaceSymbol)left.ContainingSymbol).QualifiedName != ((INamespaceSymbol)right.ContainingSymbol).QualifiedName) return false;
 #endif
             if (left.Name != right.Name) return false;
@@ -146,7 +146,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private static string GetFullyQualifiedObjectName(IPageTypeSymbol page)
         {
-#if !Fall2023OrLower
+#if !Fall2023RV1
             if (page.ContainingNamespace.QualifiedName != "")
                 return page.ContainingNamespace.QualifiedName + "." + page.Name.QuoteIdentifierIfNeeded();
 #endif

--- a/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0039ArgumentDifferentTypeThenExpected.cs
@@ -137,7 +137,7 @@ namespace BusinessCentral.LinterCop.Design
         private static bool AreTheSameNavObjects(ITableTypeSymbol left, ITableTypeSymbol right)
         {
             if (left.GetNavTypeKindSafe() != right.GetNavTypeKindSafe()) return false;
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
             if (((INamespaceSymbol)left.ContainingSymbol).QualifiedName != ((INamespaceSymbol)right.ContainingSymbol).QualifiedName) return false;
 #endif
             if (left.Name != right.Name) return false;
@@ -146,7 +146,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private static string GetFullyQualifiedObjectName(IPageTypeSymbol page)
         {
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
             if (page.ContainingNamespace.QualifiedName != "")
                 return page.ContainingNamespace.QualifiedName + "." + page.Name.QuoteIdentifierIfNeeded();
 #endif

--- a/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
@@ -36,7 +36,7 @@ namespace BusinessCentral.LinterCop.Design
                 SyntaxKind.ReportColumn,
                 SyntaxKind.EnumValue,
                 SyntaxKind.PageCustomAction,
-#if !Fall2023RV3OrLower
+#if !Spring2024
                 SyntaxKind.PageSystemAction,
 #endif
                 SyntaxKind.PageView,

--- a/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
@@ -36,7 +36,7 @@ namespace BusinessCentral.LinterCop.Design
                 SyntaxKind.ReportColumn,
                 SyntaxKind.EnumValue,
                 SyntaxKind.PageCustomAction,
-#if !Spring2024
+#if !LessThenSpring2024
                 SyntaxKind.PageSystemAction,
 #endif
                 SyntaxKind.PageView,

--- a/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
@@ -36,7 +36,7 @@ namespace BusinessCentral.LinterCop.Design
                 SyntaxKind.ReportColumn,
                 SyntaxKind.EnumValue,
                 SyntaxKind.PageCustomAction,
-#if !Spring2024
+#if !Fall2023RV3OrLower
                 SyntaxKind.PageSystemAction,
 #endif
                 SyntaxKind.PageView,

--- a/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0041EmptyCaptionLocked.cs
@@ -36,7 +36,7 @@ namespace BusinessCentral.LinterCop.Design
                 SyntaxKind.ReportColumn,
                 SyntaxKind.EnumValue,
                 SyntaxKind.PageCustomAction,
-#if PageSystemAction
+#if !Spring2024
                 SyntaxKind.PageSystemAction,
 #endif
                 SyntaxKind.PageView,

--- a/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
@@ -1,4 +1,4 @@
-#if Fall2023RV1
+#if !Fall2023RV1
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -29,7 +29,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void AnalyzeIsolatedStorage(OperationAnalysisContext ctx)
         {
-#if Spring2024
+#if !Spring2024
             if (!VersionChecker.IsSupported(ctx.ContainingSymbol, VersionCompatibility.Spring2024OrGreater)) return;
 
             if (ctx.IsObsoletePendingOrRemoved()) return;

--- a/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
@@ -1,4 +1,4 @@
-#if !Fall2023OrLower
+#if !Fall2023RV1
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -29,7 +29,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void AnalyzeIsolatedStorage(OperationAnalysisContext ctx)
         {
-#if !Fall2023RV3OrLower
+#if !Spring2024
             if (!VersionChecker.IsSupported(ctx.ContainingSymbol, VersionCompatibility.Spring2024OrGreater)) return;
 
             if (ctx.IsObsoletePendingOrRemoved()) return;

--- a/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
@@ -1,4 +1,4 @@
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -29,7 +29,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void AnalyzeIsolatedStorage(OperationAnalysisContext ctx)
         {
-#if !Spring2024
+#if !LessThenSpring2024
             if (!VersionChecker.IsSupported(ctx.ContainingSymbol, VersionCompatibility.Spring2024OrGreater)) return;
 
             if (ctx.IsObsoletePendingOrRemoved()) return;

--- a/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0043SecretText.cs
@@ -1,4 +1,4 @@
-#if !Fall2023RV1
+#if !Fall2023OrLower
 using System.Collections.Immutable;
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
@@ -29,7 +29,7 @@ namespace BusinessCentral.LinterCop.Design
 
         private void AnalyzeIsolatedStorage(OperationAnalysisContext ctx)
         {
-#if !Spring2024
+#if !Fall2023RV3OrLower
             if (!VersionChecker.IsSupported(ctx.ContainingSymbol, VersionCompatibility.Spring2024OrGreater)) return;
 
             if (ctx.IsObsoletePendingOrRemoved()) return;

--- a/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
@@ -747,7 +747,7 @@ namespace BusinessCentral.LinterCop.Design
                     string objtype = typeprop.GetValue(field).ToString();
                     string fieldClass = fieldClassProp.GetValue(field).ToString();
 
-#if !Fall2023RV1
+#if !Fall2023OrLower
                     // Remove the QualifiedName from the Enum for now.
                     // In the future refactor this to support Enums with the same object name cross different namespaces
                     IEnumBaseTypeSymbol? enumBaseTypeSymbol = typeprop.GetValue(field) as IEnumBaseTypeSymbol;

--- a/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
@@ -747,7 +747,7 @@ namespace BusinessCentral.LinterCop.Design
                     string objtype = typeprop.GetValue(field).ToString();
                     string fieldClass = fieldClassProp.GetValue(field).ToString();
 
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
                     // Remove the QualifiedName from the Enum for now.
                     // In the future refactor this to support Enums with the same object name cross different namespaces
                     IEnumBaseTypeSymbol? enumBaseTypeSymbol = typeprop.GetValue(field) as IEnumBaseTypeSymbol;

--- a/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
@@ -747,7 +747,7 @@ namespace BusinessCentral.LinterCop.Design
                     string objtype = typeprop.GetValue(field).ToString();
                     string fieldClass = fieldClassProp.GetValue(field).ToString();
 
-#if !Fall2023OrLower
+#if !Fall2023RV1
                     // Remove the QualifiedName from the Enum for now.
                     // In the future refactor this to support Enums with the same object name cross different namespaces
                     IEnumBaseTypeSymbol? enumBaseTypeSymbol = typeprop.GetValue(field) as IEnumBaseTypeSymbol;

--- a/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0044AnalyzeTransferField.cs
@@ -747,7 +747,7 @@ namespace BusinessCentral.LinterCop.Design
                     string objtype = typeprop.GetValue(field).ToString();
                     string fieldClass = fieldClassProp.GetValue(field).ToString();
 
-#if Fall2023RV1
+#if !Fall2023RV1
                     // Remove the QualifiedName from the Enum for now.
                     // In the future refactor this to support Enums with the same object name cross different namespaces
                     IEnumBaseTypeSymbol? enumBaseTypeSymbol = typeprop.GetValue(field) as IEnumBaseTypeSymbol;

--- a/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if !Fall2023RV1
+#if !Fall2023OrLower
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if Fall2023RV1
+#if !Fall2023RV1
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0051SetFilterPossibleOverflow.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if !Fall2023OrLower
+#if !Fall2023RV1
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
@@ -8,7 +8,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 using System.Collections.Immutable;
-#if !Fall2023RV3OrLower
+#if !Spring2024
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -33,7 +33,7 @@ namespace BusinessCentral.LinterCop.Design
 
             public MethodSymbolAnalyzer(CompilationAnalysisContext compilationAnalysisContext)
             {
-#if !Fall2023RV3OrLower
+#if !Spring2024
                 NavAppManifest manifest = ManifestHelper.GetManifest(compilationAnalysisContext.Compilation);
 #else
                 NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(compilationAnalysisContext.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
@@ -8,7 +8,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 using System.Collections.Immutable;
-#if !Spring2024
+#if !LessThenSpring2024
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -33,7 +33,7 @@ namespace BusinessCentral.LinterCop.Design
 
             public MethodSymbolAnalyzer(CompilationAnalysisContext compilationAnalysisContext)
             {
-#if !Spring2024
+#if !LessThenSpring2024
                 NavAppManifest manifest = ManifestHelper.GetManifest(compilationAnalysisContext.Compilation);
 #else
                 NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(compilationAnalysisContext.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
@@ -8,7 +8,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 using System.Collections.Immutable;
-#if !Spring2024
+#if !Fall2023RV3OrLower
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -33,7 +33,7 @@ namespace BusinessCentral.LinterCop.Design
 
             public MethodSymbolAnalyzer(CompilationAnalysisContext compilationAnalysisContext)
             {
-#if !Spring2024
+#if !Fall2023RV3OrLower
                 NavAppManifest manifest = ManifestHelper.GetManifest(compilationAnalysisContext.Compilation);
 #else
                 NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(compilationAnalysisContext.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0052and0053InternalProceduresNotReferenced.cs
@@ -8,7 +8,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Packaging;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
 using System.Collections.Immutable;
-#if ManifestHelper
+#if !Spring2024
 using Microsoft.Dynamics.Nav.Analyzers.Common;
 #else
 using Microsoft.Dynamics.Nav.Analyzers.Common.AppSourceCopConfiguration;
@@ -33,7 +33,7 @@ namespace BusinessCentral.LinterCop.Design
 
             public MethodSymbolAnalyzer(CompilationAnalysisContext compilationAnalysisContext)
             {
-#if ManifestHelper
+#if !Spring2024
                 NavAppManifest manifest = ManifestHelper.GetManifest(compilationAnalysisContext.Compilation);
 #else
                 NavAppManifest manifest = AppSourceCopConfigurationProvider.GetManifest(compilationAnalysisContext.Compilation);

--- a/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if !Spring2024
+#if !LessThenSpring2024
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if !Spring2024
+#if !Fall2023RV3OrLower
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if Spring2024
+#if !Spring2024
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0064UseTableFieldToolTip.cs
@@ -1,5 +1,5 @@
 #nullable disable // TODO: Enable nullable and review rule
-#if !Fall2023RV3OrLower
+#if !Spring2024
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -177,10 +177,10 @@ namespace BusinessCentral.LinterCop.Design
 
                 var objectName = typeParts[1].Trim().Trim('"');
                 if (objectName.ToLowerInvariant() != variableType.Name.ToLowerInvariant())
-#if Fall2023RV1
-                    if (objectName.UnquoteIdentifier().ToLowerInvariant() != (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant())) 
+#if !Fall2023RV1
+                    if (objectName.UnquoteIdentifier().ToLowerInvariant() != (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant()))
 #endif
-                    continue;
+                        continue;
 
                 if (permissionValue.Contains(requestedPermission.ToString().ToLowerInvariant()[0]))
                 {
@@ -227,7 +227,7 @@ namespace BusinessCentral.LinterCop.Design
                 var objectName = typeAndObjectName[typeEndIndex..].Trim().Trim('"');
 
                 bool nameSpaceNameMatch = false;
-#if Fall2023RV1
+#if !Fall2023RV1
                 nameSpaceNameMatch = objectName.UnquoteIdentifier() == (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant());
 #endif
 

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -177,7 +177,7 @@ namespace BusinessCentral.LinterCop.Design
 
                 var objectName = typeParts[1].Trim().Trim('"');
                 if (objectName.ToLowerInvariant() != variableType.Name.ToLowerInvariant())
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
                     if (objectName.UnquoteIdentifier().ToLowerInvariant() != (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant()))
 #endif
                         continue;
@@ -227,7 +227,7 @@ namespace BusinessCentral.LinterCop.Design
                 var objectName = typeAndObjectName[typeEndIndex..].Trim().Trim('"');
 
                 bool nameSpaceNameMatch = false;
-#if !Fall2023RV1
+#if !LessThenFall2023RV1
                 nameSpaceNameMatch = objectName.UnquoteIdentifier() == (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant());
 #endif
 

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -177,7 +177,7 @@ namespace BusinessCentral.LinterCop.Design
 
                 var objectName = typeParts[1].Trim().Trim('"');
                 if (objectName.ToLowerInvariant() != variableType.Name.ToLowerInvariant())
-#if !Fall2023RV1
+#if !Fall2023OrLower
                     if (objectName.UnquoteIdentifier().ToLowerInvariant() != (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant()))
 #endif
                         continue;
@@ -227,7 +227,7 @@ namespace BusinessCentral.LinterCop.Design
                 var objectName = typeAndObjectName[typeEndIndex..].Trim().Trim('"');
 
                 bool nameSpaceNameMatch = false;
-#if !Fall2023RV1
+#if !Fall2023OrLower
                 nameSpaceNameMatch = objectName.UnquoteIdentifier() == (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant());
 #endif
 

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -177,7 +177,7 @@ namespace BusinessCentral.LinterCop.Design
 
                 var objectName = typeParts[1].Trim().Trim('"');
                 if (objectName.ToLowerInvariant() != variableType.Name.ToLowerInvariant())
-#if !Fall2023OrLower
+#if !Fall2023RV1
                     if (objectName.UnquoteIdentifier().ToLowerInvariant() != (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant()))
 #endif
                         continue;
@@ -227,7 +227,7 @@ namespace BusinessCentral.LinterCop.Design
                 var objectName = typeAndObjectName[typeEndIndex..].Trim().Trim('"');
 
                 bool nameSpaceNameMatch = false;
-#if !Fall2023OrLower
+#if !Fall2023RV1
                 nameSpaceNameMatch = objectName.UnquoteIdentifier() == (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant());
 #endif
 


### PR DESCRIPTION
Reverse the logic for feature flags so that, when compiling with the latest AL Language release, feature flags do not need to be set explicitly.