### PR TITLE
New Rule0075: Record Get Procedure Arguments

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0075.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0075.cs
@@ -1,0 +1,60 @@
+namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0075
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0075");
+    }
+
+    [Test]
+    [TestCase("ImplicitConversiontCodeToEnum")]
+    [TestCase("ImplicitConversiontEnumToAnotherEnum")]
+    [TestCase("RecordGetGlobalVariable")]
+    [TestCase("RecordGetLocalVariable")]
+    [TestCase("RecordGetMethod")]
+    [TestCase("RecordGetParameter")]
+    [TestCase("RecordGetReportDataItem")]
+    [TestCase("RecordGetReturnValue")]
+    [TestCase("RecordGetSetupTableIncorrectArgumentsProvided")]
+    [TestCase("RecordGetSetupTableNoArgumentsProvided")]
+    [TestCase("RecordGetXmlPortTableElement")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0075RecordGetProcedureArguments>();
+        fixture.HasDiagnostic(code, Rule0075RecordGetProcedureArguments.DiagnosticDescriptors.Rule0075RecordGetProcedureArguments.Id);
+    }
+
+    [Test]
+    [TestCase("ImplicitConversiontIntegerToEnum")]
+    [TestCase("RecordGetBuiltInMethodRecordId")]
+    [TestCase("RecordGetFieldRecordId")]
+    [TestCase("RecordGetGlobalVariable")]
+    [TestCase("RecordGetLocalVariable")]
+    [TestCase("RecordGetLocalVariableRecordId")]
+    [TestCase("RecordGetMethod")]
+    [TestCase("RecordGetMethodRecordId")]
+    [TestCase("RecordGetParameter")]
+    [TestCase("RecordGetParameterRecordId")]
+    [TestCase("RecordGetReportDataItem")]
+    [TestCase("RecordGetReturnValue")]
+    [TestCase("RecordGetReturnValueRecordId")]
+    [TestCase("RecordGetSetupTableCorrectArgumentsProvided")]
+    [TestCase("RecordGetSetupTableNoArgumentsProvided")]
+    [TestCase("RecordGetXmlPortTableElement")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0075RecordGetProcedureArguments>();
+        fixture.NoDiagnosticAtMarker(code, Rule0075RecordGetProcedureArguments.DiagnosticDescriptors.Rule0075RecordGetProcedureArguments.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/Rule0075.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0075.cs
@@ -1,3 +1,4 @@
+#if !LessThenSpring2024
 namespace BusinessCentral.LinterCop.Test;
 
 public class Rule0075
@@ -58,3 +59,4 @@ public class Rule0075
         fixture.NoDiagnosticAtMarker(code, Rule0075RecordGetProcedureArguments.DiagnosticDescriptors.Rule0075RecordGetProcedureArguments.Id);
     }
 }
+#endif

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/ImplicitConversiontCodeToEnum.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/ImplicitConversiontCodeToEnum.al
@@ -1,0 +1,25 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SalesHeader: Record "Sales Header";
+        DocumentNo: Code[20];
+    begin
+        [|SalesHeader.Get(DocumentNo, DocumentNo)|];
+    end;
+}
+
+table 50100 "Sales Header"
+{
+    fields
+    {
+        field(1; "Document Type"; Enum "Sales Document Type") { }
+        field(2; "No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Document Type", "No.") { }
+    }
+}
+
+enum 50100 "Sales Document Type" { }

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/ImplicitConversiontEnumToAnotherEnum.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/ImplicitConversiontEnumToAnotherEnum.al
@@ -1,0 +1,27 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SalesHeader: Record "Sales Header";
+        PurchaseDocumentType: Enum "Purchase Document Type";
+        DocumentNo: Code[20];
+    begin
+        [|SalesHeader.Get(PurchaseDocumentType, DocumentNo)|];
+    end;
+}
+
+table 50100 "Sales Header"
+{
+    fields
+    {
+        field(1; "Document Type"; Enum "Sales Document Type") { }
+        field(2; "No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Document Type", "No.") { }
+    }
+}
+
+enum 50100 "Sales Document Type" { }
+enum 50101 "Purchase Document Type" { }

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetGlobalVariable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetGlobalVariable.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        ItemVariant: Record "Item Variant";
+
+    procedure MyProcedure()
+    begin
+        [|ItemVariant.Get('10000')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetLocalVariable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetLocalVariable.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get('10000')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetMethod.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetMethod.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        [|RecordReturnValue().Get('10000')|];
+    end;
+
+    procedure RecordReturnValue() ItemVariant: Record "Item Variant"
+    begin
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetParameter.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetParameter.al
@@ -1,0 +1,20 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(var ItemVariant: Record "Item Variant")
+    begin
+        [|ItemVariant.Get('10000')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetReportDataItem.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetReportDataItem.al
@@ -1,0 +1,25 @@
+report 50100 MyReport
+{
+    dataset
+    {
+        dataitem(ItemVariant; "Item Variant") { }
+    }
+
+    trigger OnPreReport()
+    begin
+        [|ItemVariant.Get('10000')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetReturnValue.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetReturnValue.al
@@ -1,0 +1,20 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure() ItemVariant: Record "Item Variant"
+    begin
+        [|ItemVariant.Get('10000')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetSetupTableIncorrectArgumentsProvided.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetSetupTableIncorrectArgumentsProvided.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        CompanyInformation: Record "Company Information";
+    begin
+        [|CompanyInformation.Get('', 12345)|];
+    end;
+}
+
+table 79 "Company Information"
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[10]) { }
+    }
+
+    keys
+    {
+        key(Key1; "Primary Key") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetSetupTableNoArgumentsProvided.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetSetupTableNoArgumentsProvided.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get()|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetXmlPortTableElement.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/HasDiagnostic/RecordGetXmlPortTableElement.al
@@ -1,0 +1,25 @@
+xmlport 50100 MyXmlport
+{
+    schema
+    {
+        tableelement(ItemVariant; "Item Variant") { }
+    }
+
+    trigger OnPreXmlPort()
+    begin
+        [|ItemVariant.Get('10000')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/ImplicitConversiontIntegerToEnum.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/ImplicitConversiontIntegerToEnum.al
@@ -6,7 +6,7 @@ codeunit 50100 MyCodeunit
         myInteger: Integer;
         DocumentNo: Code[20];
     begin
-        [|SalesHeader.Get(myInteger, DocumentNo)|];
+        [|SalesHeader.Get("Sales Document Type".FromInteger(myInteger), DocumentNo)|];
     end;
 }
 

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/ImplicitConversiontIntegerToEnum.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/ImplicitConversiontIntegerToEnum.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        SalesHeader: Record "Sales Header";
+        myInteger: Integer;
+        DocumentNo: Code[20];
+    begin
+        [|SalesHeader.Get(myInteger, DocumentNo)|];
+    end;
+}
+
+table 50100 "Sales Header"
+{
+    fields
+    {
+        field(1; "Document Type"; Enum "Sales Document Type") { }
+        field(2; "No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Document Type", "No.") { }
+    }
+}
+
+enum 50100 "Sales Document Type" { }

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetBuiltInMethodRecordId.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetBuiltInMethodRecordId.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get(ItemVariant.RecordId())|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetFieldRecordId.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetFieldRecordId.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get(ItemVariant."Record ID")|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+        field(3; "Record ID"; RecordId) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetGlobalVariable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetGlobalVariable.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        ItemVariant: Record "Item Variant";
+
+    procedure MyProcedure()
+    begin
+        [|ItemVariant.Get('10000', 'VARIANTCODE')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetLocalVariable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetLocalVariable.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get('10000', 'VARIANTCODE')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetLocalVariableRecordId.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetLocalVariableRecordId.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ItemVariant: Record "Item Variant";
+        MyRecordId: RecordId;
+    begin
+        [|ItemVariant.Get(MyRecordId)|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetMethod.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetMethod.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    begin
+        [|RecordReturnValue().Get('10000', 'VARIANTCODE')|];
+    end;
+
+    procedure RecordReturnValue() ItemVariant: Record "Item Variant"
+    begin
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetMethodRecordId.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetMethodRecordId.al
@@ -1,0 +1,26 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get(ReturnValueRecordId())|];
+    end;
+
+    procedure ReturnValueRecordId() MyRecordId: RecordId
+    begin
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetParameter.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetParameter.al
@@ -1,0 +1,20 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(var ItemVariant: Record "Item Variant")
+    begin
+        [|ItemVariant.Get('10000', 'VARIANTCODE')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetParameterRecordId.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetParameterRecordId.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure(MyRecordId: RecordId)
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get(MyRecordId)|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetReportDataItem.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetReportDataItem.al
@@ -1,0 +1,25 @@
+report 50100 MyReport
+{
+    dataset
+    {
+        dataitem(ItemVariant; "Item Variant") { }
+    }
+
+    trigger OnPreReport()
+    begin
+        [|ItemVariant.Get('10000', 'VARIANTCODE')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetReturnValue.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetReturnValue.al
@@ -1,0 +1,20 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure() ItemVariant: Record "Item Variant"
+    begin
+        [|ItemVariant.Get('10000', 'VARIANTCODE')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetReturnValueRecordId.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetReturnValueRecordId.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure() MyRecordId: RecordId
+    var
+        ItemVariant: Record "Item Variant";
+    begin
+        [|ItemVariant.Get(MyRecordId)|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetSetupTableCorrectArgumentsProvided.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetSetupTableCorrectArgumentsProvided.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        CompanyInformation: Record "Company Information";
+    begin
+        [|CompanyInformation.Get('')|];
+    end;
+}
+
+table 79 "Company Information"
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[10]) { }
+    }
+
+    keys
+    {
+        key(Key1; "Primary Key") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetSetupTableNoArgumentsProvided.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetSetupTableNoArgumentsProvided.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        CompanyInformation: Record "Company Information";
+    begin
+        [|CompanyInformation.Get()|];
+    end;
+}
+
+table 79 "Company Information"
+{
+    fields
+    {
+        field(1; "Primary Key"; Code[10]) { }
+    }
+
+    keys
+    {
+        key(Key1; "Primary Key") { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetXmlPortTableElement.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0075/NoDiagnostic/RecordGetXmlPortTableElement.al
@@ -1,0 +1,25 @@
+xmlport 50100 MyXmlport
+{
+    schema
+    {
+        tableelement(ItemVariant; "Item Variant") { }
+    }
+
+    trigger OnPreXmlPort()
+    begin
+        [|ItemVariant.Get('10000', 'VARIANTCODE')|];
+    end;
+}
+
+table 50100 "Item Variant"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Item No."; Code[20]) { }
+    }
+    keys
+    {
+        key(Key1; "Item No.", "Code") { }
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
@@ -1,3 +1,4 @@
+#if !LessThenSpring2024
 using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
@@ -157,3 +158,4 @@ public class Rule0075RecordGetProcedureArguments : DiagnosticAnalyzer
             helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0075");
     }
 }
+#endif

--- a/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
@@ -17,8 +17,8 @@ public class Rule0075RecordGetProcedureArguments : DiagnosticAnalyzer
 
     private static readonly Dictionary<NavTypeKind, HashSet<NavTypeKind>> ImplicitConversions = new()
     {
-        // Integer can be converted to Option, BigInteger and/or Enum
-        { NavTypeKind.Integer, new HashSet<NavTypeKind> { NavTypeKind.Option, NavTypeKind.BigInteger, NavTypeKind.Enum } },
+        // Integer can be converted to Option and/or BigInteger
+        { NavTypeKind.Integer, new HashSet<NavTypeKind> { NavTypeKind.Option, NavTypeKind.BigInteger } },
 
         // BigInteger can be converted to Duration
         { NavTypeKind.BigInteger, new HashSet<NavTypeKind> { NavTypeKind.Duration } },

--- a/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
@@ -1,5 +1,6 @@
 #if !LessThenSpring2024
 using BusinessCentral.LinterCop.AnalysisContextExtension;
+using BusinessCentral.LinterCop.ArgumentExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
@@ -57,7 +58,7 @@ public class Rule0075RecordGetProcedureArguments : DiagnosticAnalyzer
             return;
         }
 
-        if (operation.Instance?.Type.GetTypeSymbol().OriginalDefinition is not ITableTypeSymbol table)
+        if (operation.Instance?.Type.GetTypeSymbol()?.OriginalDefinition is not ITableTypeSymbol table)
             return;
 
         if (IsSingletonTable(table))
@@ -89,7 +90,7 @@ public class Rule0075RecordGetProcedureArguments : DiagnosticAnalyzer
         {
             if (!AreFieldCompatible(operation.Arguments[i], table.PrimaryKey.Fields[i]))
             {
-                var argumentType = GetTypeSymbol(operation.Arguments[i]);
+                var argumentType = operation.Arguments[i].GetTypeSymbol();
                 var fieldType = table.PrimaryKey.Fields[i].Type;
 
                 string expectedArgs = $"Argument at position {i + 1} has an invalid type; expected '{fieldType}', found '{argumentType}'";
@@ -104,7 +105,7 @@ public class Rule0075RecordGetProcedureArguments : DiagnosticAnalyzer
 
     private bool AreFieldCompatible(IArgument argument, IFieldSymbol field)
     {
-        var argumentType = GetTypeSymbol(argument);
+        var argumentType = argument.GetTypeSymbol();
         var fieldType = field.Type;
 
         if (argumentType == null || fieldType is null)
@@ -125,18 +126,6 @@ public class Rule0075RecordGetProcedureArguments : DiagnosticAnalyzer
             return false;
 
         return true;
-    }
-
-    private static ITypeSymbol? GetTypeSymbol(IArgument argument)
-    {
-        switch (argument.Value.Kind)
-        {
-            case OperationKind.ConversionExpression:
-                return ((IConversionExpression)argument.Value).Operand.Type;
-            case OperationKind.InvocationExpression:
-                return ((IInvocationExpression)argument.Value).TargetMethod.ReturnValueSymbol.ReturnType;
-        }
-        return null;
     }
 
     private static bool IsSingletonTable(ITableTypeSymbol table)

--- a/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0075RecordGetProcedureArguments.cs
@@ -1,0 +1,159 @@
+using BusinessCentral.LinterCop.AnalysisContextExtension;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
+using System.Collections.Immutable;
+
+namespace BusinessCentral.LinterCop.Design;
+
+[DiagnosticAnalyzer]
+public class Rule0075RecordGetProcedureArguments : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.Rule0075RecordGetProcedureArguments);
+
+    private static readonly Dictionary<NavTypeKind, HashSet<NavTypeKind>> ImplicitConversions = new()
+    {
+        // Integer can be converted to Option, BigInteger and/or Enum
+        { NavTypeKind.Integer, new HashSet<NavTypeKind> { NavTypeKind.Option, NavTypeKind.BigInteger, NavTypeKind.Enum } },
+
+        // BigInteger can be converted to Duration
+        { NavTypeKind.BigInteger, new HashSet<NavTypeKind> { NavTypeKind.Duration } },
+
+        // Code can be converted to Text
+        { NavTypeKind.Code, new HashSet<NavTypeKind> { NavTypeKind.Text } },
+
+        // Text can be converted to Code
+        { NavTypeKind.Text, new HashSet<NavTypeKind> { NavTypeKind.Code } },
+
+        // String(literal) can be converted to Text and/or Code
+        { NavTypeKind.String, new HashSet<NavTypeKind> { NavTypeKind.Text, NavTypeKind.Code } }
+    };
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterOperationAction(AnalyzeAssignmentStatement, OperationKind.InvocationExpression);
+    }
+
+    private void AnalyzeAssignmentStatement(OperationAnalysisContext ctx)
+    {
+        if (ctx.IsObsoletePendingOrRemoved())
+            return;
+
+        if (ctx.Operation is not IInvocationExpression operation)
+            return;
+
+        if (operation.TargetMethod.MethodKind != MethodKind.BuiltInMethod ||
+            !SemanticFacts.IsSameName(operation.TargetMethod.Name, "Get"))
+            return;
+
+        // Skip unsupported single argument scenarios, like Record.Get(RecordId)
+        if (operation.Arguments.Length == 1 &&
+            operation.Arguments[0].Value is IConversionExpression { Operand.Type: { } type } &&
+            type.GetTypeSymbol().GetNavTypeKindSafe() == NavTypeKind.RecordId)
+        {
+            return;
+        }
+
+        if (operation.Instance?.Type.GetTypeSymbol().OriginalDefinition is not ITableTypeSymbol table)
+            return;
+
+        if (IsSingletonTable(table))
+        {
+            if (operation.Arguments.Length == 0)
+                return;
+
+            if (operation.Arguments.Length == 1 &&
+                 operation.Arguments[0].Value is IConversionExpression { Operand.ConstantValue: { HasValue: true } constant } &&
+                constant.Value?.ToString() == "")
+            {
+                return;
+            }
+        }
+
+        if (operation.Arguments.Length != table.PrimaryKey.Fields.Length)
+        {
+            string expectedArgs = operation.Arguments.Length < table.PrimaryKey.Fields.Length
+                ? $"Insufficient arguments provided; expected {table.PrimaryKey.Fields.Length} arguments"
+                : $"Too many arguments provided; expected {table.PrimaryKey.Fields.Length} arguments";
+
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.Rule0075RecordGetProcedureArguments,
+                ctx.Operation.Syntax.GetLocation(), new object[] { table.Name.QuoteIdentifierIfNeeded(), expectedArgs }));
+            return;
+        }
+
+        for (int i = 0; i < operation.Arguments.Length; i++)
+        {
+            if (!AreFieldCompatible(operation.Arguments[i], table.PrimaryKey.Fields[i]))
+            {
+                var argumentType = GetTypeSymbol(operation.Arguments[i]);
+                var fieldType = table.PrimaryKey.Fields[i].Type;
+
+                string expectedArgs = $"Argument at position {i + 1} has an invalid type; expected '{fieldType}', found '{argumentType}'";
+
+                ctx.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.Rule0075RecordGetProcedureArguments,
+                    ctx.Operation.Syntax.GetLocation(), new object[] { table.Name.QuoteIdentifierIfNeeded(), expectedArgs }));
+                return;
+            }
+        }
+    }
+
+    private bool AreFieldCompatible(IArgument argument, IFieldSymbol field)
+    {
+        var argumentType = GetTypeSymbol(argument);
+        var fieldType = field.Type;
+
+        if (argumentType == null || fieldType is null)
+            return true;
+
+        var argumentNavType = argumentType.GetNavTypeKindSafe();
+        var fieldNavType = fieldType.GetNavTypeKindSafe();
+
+        if (argumentNavType == NavTypeKind.Enum && fieldNavType == NavTypeKind.Enum)
+            return argumentType.OriginalDefinition == fieldType.OriginalDefinition;
+
+        if (argumentNavType == fieldNavType ||
+            argumentNavType == NavTypeKind.None ||
+            argumentNavType == NavTypeKind.Joker)
+            return true;
+
+        if (ImplicitConversions.TryGetValue(argumentNavType, out var compatibleTypes) && !compatibleTypes.Contains(fieldNavType))
+            return false;
+
+        return true;
+    }
+
+    private static ITypeSymbol? GetTypeSymbol(IArgument argument)
+    {
+        switch (argument.Value.Kind)
+        {
+            case OperationKind.ConversionExpression:
+                return ((IConversionExpression)argument.Value).Operand.Type;
+            case OperationKind.InvocationExpression:
+                return ((IInvocationExpression)argument.Value).TargetMethod.ReturnValueSymbol.ReturnType;
+        }
+        return null;
+    }
+
+    private static bool IsSingletonTable(ITableTypeSymbol table)
+    {
+        return table.PrimaryKey.Fields.Length == 1 &&
+            table.PrimaryKey.Fields[0].OriginalDefinition.GetTypeSymbol() is { } typeSymbol &&
+            typeSymbol.GetNavTypeKindSafe() == NavTypeKind.Code;
+    }
+
+    public static class DiagnosticDescriptors
+    {
+        public static readonly DiagnosticDescriptor Rule0075RecordGetProcedureArguments = new(
+            id: LinterCopAnalyzers.AnalyzerPrefix + "0075",
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0075RecordGetProcedureArgumentsTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0075RecordGetProcedureArgumentsFormat"),
+            category: "Design",
+            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: LinterCopAnalyzers.GetLocalizableString("Rule0075RecordGetProcedureArgumentsDescription"),
+            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0075");
+    }
+}

--- a/BusinessCentral.LinterCop/Helpers/ArgumentHelper.cs
+++ b/BusinessCentral.LinterCop/Helpers/ArgumentHelper.cs
@@ -1,0 +1,19 @@
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+
+namespace BusinessCentral.LinterCop.ArgumentExtension
+{
+    public static class ArgumentExtensions
+    {
+        public static ITypeSymbol? GetTypeSymbol(this IArgument argument)
+        {
+            switch (argument.Value.Kind)
+            {
+                case OperationKind.ConversionExpression:
+                    return ((IConversionExpression)argument.Value).Operand.Type;
+                case OperationKind.InvocationExpression:
+                    return ((IInvocationExpression)argument.Value).TargetMethod.ReturnValueSymbol.ReturnType;
+            }
+            return null;
+        }
+    }
+}

--- a/BusinessCentral.LinterCop/LinterCop.ruleset.json
+++ b/BusinessCentral.LinterCop/LinterCop.ruleset.json
@@ -371,6 +371,11 @@
       "id": "LC0074",
       "action": "Warning",
       "justification": "Set values for FlowFilter fields using filtering methods."
+    },
+    {
+      "id": "LC0075",
+      "action": "Warning",
+      "justification": "Incorrect number or type of arguments in .Get() method on Record object."
     }
   ]
 }

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -786,4 +786,13 @@
   <data name="Rule0074FlowFilterAssignmentDescription" xml:space="preserve">
     <value>Directly assigning values to FlowFilter fields bypasses their purpose and invalidates the filtering logic, resulting in incorrect or unintended calculations. Instead, use the .SetFilter() or .SetRange() methods to define the appropriate filters.</value>
   </data>
+  <data name="Rule0075RecordGetProcedureArgumentsTitle" xml:space="preserve">
+    <value>Incorrect number or type of arguments in .Get() method on Record object.</value>
+  </data>
+  <data name="Rule0075RecordGetProcedureArgumentsFormat" xml:space="preserve">
+    <value>Invalid arguments in .Get() method for record {0}: {1}.</value>
+  </data>
+  <data name="Rule0075RecordGetProcedureArgumentsDescription" xml:space="preserve">
+    <value>This rule ensures that calls to the built-in .Get() procedure on Record objects have the correct number and types of arguments matching the primary key (PK) of the record in question.</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -228,3 +228,4 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 |[LC0072](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0072)|The documentation comment must match the procedure syntax.|Info|
 |[LC0073](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0073)|Handled parameters in event signatures should be passed by var.|Warning|
 |[LC0074](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0074)|Set values for FlowFilter fields using filtering methods.|Warning|
+|[LC0075](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0075)|Incorrect number or type of arguments in `.Get()` method on Record object.|Warning|

--- a/README.md
+++ b/README.md
@@ -228,4 +228,4 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 |[LC0072](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0072)|The documentation comment must match the procedure syntax.|Info|
 |[LC0073](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0073)|Handled parameters in event signatures should be passed by var.|Warning|
 |[LC0074](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0074)|Set values for FlowFilter fields using filtering methods.|Warning|
-|[LC0075](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0075)|Incorrect number or type of arguments in `.Get()` method on Record object.|Warning|
+|[LC0075](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0075)|Incorrect number or type of arguments in `.Get()` method on Record object.|Warning|13.0


### PR DESCRIPTION
Discussion: https://github.com/StefanMaron/BusinessCentral.LinterCop/discussions/85

Thank you @rvanbekkum for providing the [test cases](https://github.com/StefanMaron/BusinessCentral.LinterCop/discussions/85#discussioncomment-11016049)!

I could use some feedback on this new rule, as my intention is to have set the default severity as a warning for this new rule, where I want to prevent possible false positives.

Some remarks on this PR:

**Implicit conversation**

```AL
procedure GetSalesOrder(DocumentNo: Code[20])
var
    SalesOrder: Record "Sales Header";
begin
    SalesOrder.Get(1, DocumentNo);
end;
```

Not the best example, but I want to allow this in this rule (and maybe have [LC0003](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0003) report on this).

For now I have these implicit conversation in place, where I don't have a lot of examples where the parameter type is different then the field type on the table. Could use some input on this if I need to add or remove some conversions here.

|Parameter in .Get()|Table field type|
|--|--|
|Integer|Option|
|Integer|BigInteger|
|Integer|Enum|
|BigInteger|Duration|
|Code|Text|
|Text|Code|
|String(literal)|Text|
|String(literal)|Code|

_String(literal) can be a hard coded value directly in code or for example a Label value._

**Enums**
Currently I expect the provided Enum to be exactly the same as the Enum declaration of the field. Are there exceptions on this I need to take into account?

**Setup Table**
For a setup table, where I expect the [Singleton Pattern](https://alguidelines.dev/docs/navpatterns/patterns/singleton/singleton-table/), a `.Get()` call without any values should be sufficiënt. I've now created the check that when a table has one a single primary key of type `Code`, the rule will handle this as a setup table. Potentially this could raise a false positive on a table with a single primary key of another type, like for example `Text`?

**Length of Code/Text field**
Currently the rule will not raise on a Code[20] argument on a Code[10] field, which can possibly create a overflow. I'm looking into handling this with the [LC0051](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0051) rule. 