### PR TITLE
Add Too Long Table Relation Check

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0076.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0076.cs
@@ -32,7 +32,6 @@ public class Rule0076
     [TestCase("TableExtRelationEqual")]
     [TestCase("TableExtRelationShorter")]
 #endif
-    [TestCase("TableExtRelationShorter")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/Rule0076.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0076.cs
@@ -1,0 +1,39 @@
+namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0076
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0076");
+    }
+
+    [Test]
+    [TestCase("TableRelationLonger")]
+    [TestCase("TableExtRelationShorter")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0076TableRelationTooLong>();
+        fixture.HasDiagnostic(code, Rule0076TableRelationTooLong.DiagnosticDescriptors.Rule0076TableRelationTooLong.Id);
+    }
+
+    [Test]
+    [TestCase("TableRelationEqual")]
+    [TestCase("TableRelationShorter")]
+    [TestCase("TableExtRelationEqual")]
+    [TestCase("TableExtRelationLonger")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0076TableRelationTooLong>();
+        fixture.NoDiagnosticAtMarker(code, Rule0076TableRelationTooLong.DiagnosticDescriptors.Rule0076TableRelationTooLong.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/Rule0076.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0076.cs
@@ -28,7 +28,10 @@ public class Rule0076
     [Test]
     [TestCase("TableRelationEqual")]
     [TestCase("TableRelationShorter")]
+#if !LessThenSpring2024
     [TestCase("TableExtRelationEqual")]
+    [TestCase("TableExtRelationShorter")]
+#endif
     [TestCase("TableExtRelationShorter")]
     public async Task NoDiagnostic(string testCase)
     {

--- a/BusinessCentral.LinterCop.Test/Rule0076.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0076.cs
@@ -13,7 +13,7 @@ public class Rule0076
 
     [Test]
     [TestCase("TableRelationLonger")]
-    [TestCase("TableExtRelationShorter")]
+    [TestCase("TableExtRelationLonger")]
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
@@ -27,7 +27,7 @@ public class Rule0076
     [TestCase("TableRelationEqual")]
     [TestCase("TableRelationShorter")]
     [TestCase("TableExtRelationEqual")]
-    [TestCase("TableExtRelationLonger")]
+    [TestCase("TableExtRelationShorter")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/Rule0076.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0076.cs
@@ -13,7 +13,9 @@ public class Rule0076
 
     [Test]
     [TestCase("TableRelationLonger")]
+#if !LessThenSpring2024
     [TestCase("TableExtRelationLonger")]
+#endif
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/HasDiagnostic/TableExtRelationLonger.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/HasDiagnostic/TableExtRelationLonger.al
@@ -1,0 +1,33 @@
+table 50108 MyTable
+{
+    fields
+    {
+        field(1; [|MyText|]; Text[1])
+        {
+            TableRelation = MyTable.MyTextExt;
+        }
+
+        field(2; [|MyCode|]; Text[1])
+        {
+            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt 
+            else 
+            MyTable.MyTextExt;
+        }
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}
+
+
+tableextension 50108 MyExtension extends MyTable
+{
+    fields
+    {
+        field(3; MyTextExt; Text[100]) { }
+
+        field(4; MyCodeExt; Text[100]) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/HasDiagnostic/TableExtRelationLonger.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/HasDiagnostic/TableExtRelationLonger.al
@@ -4,14 +4,14 @@ table 50108 MyTable
     {
         field(1; [|MyText|]; Text[1])
         {
-            TableRelation = MyTable.MyTextExt;
+            TableRelation = MyTable2.MyTextExt;
         }
 
         field(2; [|MyCode|]; Text[1])
         {
-            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt 
+            TableRelation = if (MyCode = const('const')) MyTable2.MyCodeExt 
             else 
-            MyTable.MyTextExt;
+            MyTable2.MyTextExt;
         }
     }
 
@@ -22,7 +22,23 @@ table 50108 MyTable
 }
 
 
-tableextension 50108 MyExtension extends MyTable
+table 50107 MyTable2
+{
+    fields
+    {
+        field(1; MyText; Text[1]) { }
+
+        field(2; MyCode; Text[1]) { }
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}
+
+
+tableextension 50110 MyExtension extends MyTable2
 {
     fields
     {

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/HasDiagnostic/TableRelationLonger.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/HasDiagnostic/TableRelationLonger.al
@@ -1,0 +1,25 @@
+table 50108 MyTable
+{
+    fields
+    {
+        field(1; [|MyText|]; Text[1])
+        {
+            TableRelation = MyTable.MyTextExt;
+        }
+
+        field(2; [|MyCode|]; Text[1])
+        {
+            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt
+            else 
+            MyTable.MyTextExt;
+        }
+        field(3; MyTextExt; Text[100]) { }
+
+        field(4; MyCodeExt; Text[100]) { }        
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationEqual.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationEqual.al
@@ -1,0 +1,33 @@
+table 50108 MyTable
+{
+    fields
+    {
+        field(1; [|MyText|]; Text[100])
+        {
+            TableRelation = MyTable.MyTextExt;
+        }
+
+        field(2; [|MyCode|]; Text[100])
+        {
+            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt 
+            else 
+            MyTable.MyTextExt;
+        }
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}
+
+
+tableextension 50108 MyExtension extends MyTable
+{
+    fields
+    {
+        field(3; MyTextExt; Text[100]) { }
+
+        field(4; MyCodeExt; Text[100]) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationEqual.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationEqual.al
@@ -4,14 +4,14 @@ table 50108 MyTable
     {
         field(1; [|MyText|]; Text[100])
         {
-            TableRelation = MyTable.MyTextExt;
+            TableRelation = MyTable2.MyTextExt;
         }
 
         field(2; [|MyCode|]; Text[100])
         {
-            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt 
+            TableRelation = if (MyCode = const('const')) MyTable2.MyCodeExt 
             else 
-            MyTable.MyTextExt;
+            MyTable2.MyTextExt;
         }
     }
 
@@ -22,7 +22,23 @@ table 50108 MyTable
 }
 
 
-tableextension 50108 MyExtension extends MyTable
+table 50107 MyTable2
+{
+    fields
+    {
+        field(1; MyText; Text[1]) { }
+
+        field(2; MyCode; Text[1]) { }
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}
+
+
+tableextension 50110 MyExtension extends MyTable2
 {
     fields
     {

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationShorter.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationShorter.al
@@ -1,0 +1,33 @@
+table 50108 MyTable
+{
+    fields
+    {
+        field(1; [|MyText|]; Text[200])
+        {
+            TableRelation = MyTable.MyTextExt;
+        }
+
+        field(2; [|MyCode|]; Text[200])
+        {
+            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt 
+            else 
+            MyTable.MyTextExt;
+        }
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}
+
+
+tableextension 50108 MyExtension extends MyTable
+{
+    fields
+    {
+        field(3; MyTextExt; Text[100]) { }
+
+        field(4; MyCodeExt; Text[100]) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationShorter.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableExtRelationShorter.al
@@ -4,14 +4,14 @@ table 50108 MyTable
     {
         field(1; [|MyText|]; Text[200])
         {
-            TableRelation = MyTable.MyTextExt;
+            TableRelation = MyTable2.MyTextExt;
         }
 
         field(2; [|MyCode|]; Text[200])
         {
-            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt 
+            TableRelation = if (MyCode = const('const')) MyTable2.MyCodeExt 
             else 
-            MyTable.MyTextExt;
+            MyTable2.MyTextExt;
         }
     }
 
@@ -21,8 +21,23 @@ table 50108 MyTable
     }
 }
 
+table 50107 MyTable2
+{
+    fields
+    {
+        field(1; MyText; Text[1]) { }
 
-tableextension 50108 MyExtension extends MyTable
+        field(2; MyCode; Text[1]) { }
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}
+
+
+tableextension 50110 MyExtension extends MyTable2
 {
     fields
     {

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableRelationEqual.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableRelationEqual.al
@@ -1,0 +1,25 @@
+table 50108 MyTable
+{
+    fields
+    {
+        field(1; [|MyText|]; Text[100])
+        {
+            TableRelation = MyTable.MyTextExt;
+        }
+
+        field(2; [|MyCode|]; Text[100])
+        {
+            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt
+            else 
+            MyTable.MyTextExt;
+        }
+        field(3; MyTextExt; Text[100]) { }
+
+        field(4; MyCodeExt; Text[100]) { }        
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableRelationShorter.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0076/NoDiagnostic/TableRelationShorter.al
@@ -1,0 +1,25 @@
+table 50108 MyTable
+{
+    fields
+    {
+        field(1; [|MyText|]; Text[200])
+        {
+            TableRelation = MyTable.MyTextExt;
+        }
+
+        field(2; [|MyCode|]; Text[200])
+        {
+            TableRelation = if (MyCode = const('const')) MyTable.MyCodeExt
+            else 
+            MyTable.MyTextExt;
+        }
+        field(3; MyTextExt; Text[100]) { }
+
+        field(4; MyCodeExt; Text[100]) { }        
+    }
+
+    keys
+    {
+        key(PK; MyText) { Clustered = true; }
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
@@ -1,4 +1,4 @@
-using BusinessCentral.LinterCop.AnalysisContextExtension;
+﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
@@ -89,11 +89,8 @@ public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
 
     private static IFieldSymbol? GetFieldFromTableExtension(string tableName, string fieldName, Compilation compilation)
     {
-        var extensions = compilation.GetDeclaredApplicationObjectSymbols()
-            .Where(x => x.Kind == SymbolKind.TableExtension)
-            .Cast<ITableExtensionTypeSymbol>();
-
-        return extensions
+        return compilation.GetDeclaredApplicationObjectSymbols()
+            .OfType<ITableExtensionTypeSymbol>()
             .Where(ext => ext.Target?.Name == tableName)
             .SelectMany(ext => ext.AddedFields)
             .FirstOrDefault(field => field.Name == fieldName);

--- a/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
@@ -21,7 +21,7 @@ public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
         if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not IFieldSymbol currentField)
             return;
 
-        if (currentField.GetProperty(PropertyKind.TableRelation)?.GetPropertyValueSyntax<TableRelationPropertyValueSyntax>() 
+        if (currentField.GetProperty(PropertyKind.TableRelation)?.GetPropertyValueSyntax<TableRelationPropertyValueSyntax>()
             is not TableRelationPropertyValueSyntax tableRelation)
             return;
 
@@ -50,11 +50,11 @@ public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
     }
 
     private static bool ShouldReportDiagnostic(IFieldSymbol currentField, IFieldSymbol? relatedField) =>
-        relatedField?.HasLength == true && 
-        currentField.HasLength && 
+        relatedField?.HasLength == true &&
+        currentField.HasLength &&
         currentField.Length < relatedField.Length;
 
-    private static void ReportLengthMismatch(SyntaxNodeAnalysisContext context, IFieldSymbol currentField, 
+    private static void ReportLengthMismatch(SyntaxNodeAnalysisContext context, IFieldSymbol currentField,
         IFieldSymbol relatedField, QualifiedNameSyntax relatedFieldSyntax)
     {
         context.ReportDiagnostic(Diagnostic.Create(
@@ -68,11 +68,11 @@ public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
 
     private IFieldSymbol? GetRelatedFieldSymbol(IdentifierNameSyntax? table, IdentifierNameSyntax? field, Compilation compilation)
     {
-        if (table?.GetIdentifierOrLiteralValue() is not string tableName || 
+        if (table?.GetIdentifierOrLiteralValue() is not string tableName ||
             field?.GetIdentifierOrLiteralValue() is not string fieldName)
             return null;
 
-        return GetFieldFromTable(tableName, fieldName, compilation) ?? 
+        return GetFieldFromTable(tableName, fieldName, compilation) ??
                GetFieldFromTableExtension(tableName, fieldName, compilation);
     }
 
@@ -95,17 +95,17 @@ public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
             .SelectMany(ext => ext.AddedFields)
             .FirstOrDefault(field => field.Name == fieldName);
     }
-}
 
-public static class DiagnosticDescriptors
-{
-    public static readonly DiagnosticDescriptor Rule0076TableRelationTooLong = new(
-        id: LinterCopAnalyzers.AnalyzerPrefix + "0076",
-        title: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongTitle"),
-        messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongFormat"),
-        category: "Design",
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        description: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongDescription"),
-        helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0076");
+    public static class DiagnosticDescriptors
+    {
+        public static readonly DiagnosticDescriptor Rule0076TableRelationTooLong = new(
+            id: LinterCopAnalyzers.AnalyzerPrefix + "0076",
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongFormat"),
+            category: "Design",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongDescription"),
+            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0076");
+    }
 }

--- a/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
@@ -1,0 +1,111 @@
+﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
+
+namespace BusinessCentral.LinterCop.Design;
+[DiagnosticAnalyzer]
+public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.Rule0076TableRelationTooLong);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.Field);
+
+    private void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+    {
+        if (context.IsObsoletePendingOrRemoved())
+            return;
+
+        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not IFieldSymbol currentField)
+            return;
+
+        if (currentField.GetProperty(PropertyKind.TableRelation)?.GetPropertyValueSyntax<TableRelationPropertyValueSyntax>() 
+            is not TableRelationPropertyValueSyntax tableRelation)
+            return;
+
+        AnalyzeTableRelations(context, currentField, tableRelation);
+    }
+
+    private void AnalyzeTableRelations(SyntaxNodeAnalysisContext context, IFieldSymbol currentField, TableRelationPropertyValueSyntax? tableRelation)
+    {
+        while (tableRelation is not null)
+        {
+            if (tableRelation.RelatedTableField is QualifiedNameSyntax relatedField)
+            {
+                var relatedFieldSymbol = GetRelatedFieldSymbol(
+                    relatedField.Left as IdentifierNameSyntax,
+                    relatedField.Right as IdentifierNameSyntax,
+                    context.SemanticModel.Compilation);
+
+                if (relatedFieldSymbol is not null && ShouldReportDiagnostic(currentField, relatedFieldSymbol))
+                {
+                    ReportLengthMismatch(context, currentField, relatedFieldSymbol, relatedField);
+                }
+            }
+
+            tableRelation = tableRelation.ElseExpression?.ElseTableRelationCondition;
+        }
+    }
+
+    private static bool ShouldReportDiagnostic(IFieldSymbol currentField, IFieldSymbol? relatedField) =>
+        relatedField?.HasLength == true && 
+        currentField.HasLength && 
+        currentField.Length < relatedField.Length;
+
+    private static void ReportLengthMismatch(SyntaxNodeAnalysisContext context, IFieldSymbol currentField, 
+        IFieldSymbol relatedField, QualifiedNameSyntax relatedFieldSyntax)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.Rule0076TableRelationTooLong,
+            ((FieldSyntax)context.Node).Type.GetLocation(),
+            relatedField.Length,
+            relatedFieldSyntax.ToString(),
+            currentField.Length,
+            currentField.Name));
+    }
+
+    private IFieldSymbol? GetRelatedFieldSymbol(IdentifierNameSyntax? table, IdentifierNameSyntax? field, Compilation compilation)
+    {
+        if (table?.GetIdentifierOrLiteralValue() is not string tableName || 
+            field?.GetIdentifierOrLiteralValue() is not string fieldName)
+            return null;
+
+        return GetFieldFromTable(tableName, fieldName, compilation) ?? 
+               GetFieldFromTableExtension(tableName, fieldName, compilation);
+    }
+
+    private static IFieldSymbol? GetFieldFromTable(string tableName, string fieldName, Compilation compilation)
+    {
+        var tables = compilation.GetApplicationObjectTypeSymbolsByNameAcrossModules(SymbolKind.Table, tableName);
+        return tables.FirstOrDefault() is ITableTypeSymbol tableSymbol
+            ? tableSymbol.Fields.FirstOrDefault(x => x.Name == fieldName)
+            : null;
+    }
+
+    private static IFieldSymbol? GetFieldFromTableExtension(string tableName, string fieldName, Compilation compilation)
+    {
+        var extensions = compilation.GetDeclaredApplicationObjectSymbols()
+            .Where(x => x.Kind == SymbolKind.TableExtension)
+            .Cast<ITableExtensionTypeSymbol>();
+
+        return extensions
+            .Where(ext => ext.Target?.Name == tableName)
+            .SelectMany(ext => ext.AddedFields)
+            .FirstOrDefault(field => field.Name == fieldName);
+    }
+}
+
+public static class DiagnosticDescriptors
+{
+    public static readonly DiagnosticDescriptor Rule0076TableRelationTooLong = new(
+        id: LinterCopAnalyzers.AnalyzerPrefix + "0076",
+        title: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongTitle"),
+        messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongFormat"),
+        category: "Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: LinterCopAnalyzers.GetLocalizableString("Rule0076TableRelationTooLongDescription"),
+        helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0076");
+}

--- a/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
@@ -1,4 +1,4 @@
-﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+using BusinessCentral.LinterCop.AnalysisContextExtension;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
@@ -21,8 +21,11 @@ public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
         if (context.Symbol is not IFieldSymbol currentField)
             return;
 
-        if (currentField.GetProperty(PropertyKind.TableRelation)?.GetPropertyValueSyntax<TableRelationPropertyValueSyntax>()
-            is not TableRelationPropertyValueSyntax tableRelation)
+        var tableRelation = currentField
+            .GetProperty(PropertyKind.TableRelation)
+            ?.GetPropertyValueSyntax<TableRelationPropertyValueSyntax>();
+            
+        if (tableRelation is null)
             return;
 
         AnalyzeTableRelations(context, currentField, tableRelation);

--- a/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0076TableRelationTooLong.cs
@@ -18,7 +18,8 @@ public class Rule0076TableRelationTooLong : DiagnosticAnalyzer
         if (context.IsObsoletePendingOrRemoved())
             return;
 
-        var currentField = (IFieldSymbol)context.Symbol;
+        if (context.Symbol is not IFieldSymbol currentField)
+            return;
 
         if (currentField.GetProperty(PropertyKind.TableRelation)?.GetPropertyValueSyntax<TableRelationPropertyValueSyntax>()
             is not TableRelationPropertyValueSyntax tableRelation)

--- a/BusinessCentral.LinterCop/LinterCop.ruleset.json
+++ b/BusinessCentral.LinterCop/LinterCop.ruleset.json
@@ -371,6 +371,11 @@
       "id": "LC0074",
       "action": "Warning",
       "justification": "Set values for FlowFilter fields using filtering methods."
-    }
+    },
+    {
+      "id": "LC0076",
+      "action": "Warning",
+      "justification": "The field with table relation should have at least the same length as the referenced field."
+    }    
   ]
 }

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -786,4 +786,13 @@
   <data name="Rule0074FlowFilterAssignmentDescription" xml:space="preserve">
     <value>Directly assigning values to FlowFilter fields bypasses their purpose and invalidates the filtering logic, resulting in incorrect or unintended calculations. Instead, use the .SetFilter() or .SetRange() methods to define the appropriate filters.</value>
   </data>
+  <data name="Rule0076TableRelationTooLongTitle" xml:space="preserve">
+    <value>Table relation field length mismatch</value>
+  </data>
+  <data name="Rule0076TableRelationTooLongFormat" xml:space="preserve">
+    <value>The related field has length {0} ({1}) which is longer than the current field length {2} ({3})</value>
+  </data>
+  <data name="Rule0076TableRelationTooLongDescription" xml:space="preserve">
+    <value>The field with table relation should have at least the same length as the referenced field.</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Github All Releases](https://img.shields.io/github/v/release/StefanMaron/BusinessCentral.LinterCop?label=latest%20version)]()
 [![Github All Releases](https://img.shields.io/github/downloads/StefanMaron/BusinessCentral.LinterCop/latest/total?label=downloads%20latest%20version)]()
 
-This code analyzer is meant to check your code for all sorts of problems. Be it code that tecnically compiles but will generate errors during runtime or more a kind of guideline check to achieve cleaner code. Some rule even are disabled by default as they may not go along the main coding guidelines but are maybe helpful in certain projects. In general all rule ideas are welcome, even if they should be and maybe will be covered by Microsoft at some point but could be part of the linter in the meantime.
+This code analyzer is meant to check your code for all sorts of problems. Be it code that technically compiles but will generate errors during runtime or more a kind of guideline check to achieve cleaner code. Some rule even are disabled by default as they may not go along the main coding guidelines but are maybe helpful in certain projects. In general all rule ideas are welcome, even if they should be and maybe will be covered by Microsoft at some point but could be part of the linter in the meantime.
 
-If you are not happy with some rules or only feel like you need one rule of this analyzer, you can always control the rules with a [Custom.ruleset.json](LinterCop.ruleset.json) and disable all rules you dont need.
+If you are not happy with some rules or only feel like you need one rule of this analyzer, you can always control the rules with a [Custom.ruleset.json](LinterCop.ruleset.json) and disable all rules you don't need.
 
 ## Please Contribute!
 
@@ -153,7 +153,7 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 
 |Id| Title|Default Severity|AL version|
 |---|---|---|---|
-|[LC0000](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0000)|An error ocurred in a given rule. Please create an issue on GitHub|Info|
+|[LC0000](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0000)|An error occurred in a given rule. Please create an issue on GitHub|Info|
 |[LC0001](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0001)|FlowFields should not be editable.|Warning|
 |[LC0002](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0002)|`Commit()` needs a comment to justify its existence. Either a leading or a trailing comment.|Warning|
 |[LC0003](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0003)|Do not use an Object ID for properties or variable declarations.|Warning|
@@ -228,3 +228,4 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 |[LC0072](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0072)|The documentation comment must match the procedure syntax.|Info|
 |[LC0073](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0073)|Handled parameters in event signatures should be passed by var.|Warning|
 |[LC0074](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0074)|Set values for FlowFilter fields using filtering methods.|Warning|
+|[LC0076](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0076)|The field with table relation should have at least the same length as the referenced field.|Warning|


### PR DESCRIPTION
Adds a rule that checks if the field's length could cause issues with any of the defined table relations.

Checks through the whole chain of if-else table relations