### PR TITLE
New rules: Missing brackets - Triggers on Temporary records - Non-Public Event Publishers

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0077.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0077.cs
@@ -1,0 +1,35 @@
+namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0077
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0077");
+    }
+
+    [Test]
+    [TestCase("NoBrackets")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0077MissingParenthesis>();
+        fixture.HasDiagnostic(code, Rule0077MissingParenthesis.DiagnosticDescriptors.Rule0077MissingParenthesis.Id);
+    }
+
+    [Test]
+    [TestCase("Brackets")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0077MissingParenthesis>();
+        fixture.NoDiagnosticAtMarker(code, Rule0077MissingParenthesis.DiagnosticDescriptors.Rule0077MissingParenthesis.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/Rule0078.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0078.cs
@@ -1,0 +1,37 @@
+namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0078
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0078");
+    }
+
+    [Test]
+    [TestCase("TempVar")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0078TemporaryRecordsShouldNotTriggerTableTriggers>();
+        fixture.HasDiagnostic(code, Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.Id);
+    }
+
+    [Test]
+    [TestCase("TempVarImplicit")]
+    [TestCase("TempVarExplicit")]
+    [TestCase("TempTable")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0078TemporaryRecordsShouldNotTriggerTableTriggers>();
+        fixture.NoDiagnosticAtMarker(code, Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/Rule0078.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0078.cs
@@ -26,6 +26,7 @@ public class Rule0078
     [TestCase("TempVarImplicit")]
     [TestCase("TempVarExplicit")]
     [TestCase("TempTable")]
+    [TestCase("TempTableExplicitTemp")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/Rule0079.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0079.cs
@@ -1,0 +1,36 @@
+namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0079
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0079");
+    }
+
+    [Test]
+    [TestCase("PublicEvent")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0079NonPublicEventPublisher>();
+        fixture.HasDiagnostic(code, Rule0079NonPublicEventPublisher.DiagnosticDescriptors.Rule0079NonPublicEventPublisher.Id);
+    }
+
+    [Test]
+    [TestCase("LocalEvent")]
+    [TestCase("InternalEvent")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0079NonPublicEventPublisher>();
+        fixture.NoDiagnosticAtMarker(code, Rule0079NonPublicEventPublisher.DiagnosticDescriptors.Rule0079NonPublicEventPublisher.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0077/HasDiagnostic/NoBrackets.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0077/HasDiagnostic/NoBrackets.al
@@ -9,8 +9,8 @@ codeunit 50100 MyCodeunit
         [|Today|];
         [|WorkDate|];
         [|GuiAllowed|];
-        i := [|MyTable.Count|];
-        b := [|MyTable.IsEmpty|];
+        i := MyTable.[|Count|];
+        b := MyTable.[|IsEmpty|];
     end;
 }
 

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0077/HasDiagnostic/NoBrackets.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0077/HasDiagnostic/NoBrackets.al
@@ -1,0 +1,23 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        i: Integer;
+        b: Boolean;
+    begin
+        [|Today|];
+        [|WorkDate|];
+        [|GuiAllowed|];
+        i := [|MyTable.Count|];
+        b := [|MyTable.IsEmpty|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0077/NoDiagnostic/Brackets.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0077/NoDiagnostic/Brackets.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+        i: Integer;
+        b: Boolean;
+        d: Date;
+    begin
+        d := [|Today()|];
+        d := [|WorkDate()|];
+        b := [|GuiAllowed()|];
+        i := [|MyTable.Count()|];
+        b := [|MyTable.IsEmpty()|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0077/NoDiagnostic/Brackets.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0077/NoDiagnostic/Brackets.al
@@ -10,8 +10,8 @@ codeunit 50100 MyCodeunit
         d := [|Today()|];
         d := [|WorkDate()|];
         b := [|GuiAllowed()|];
-        i := [|MyTable.Count()|];
-        b := [|MyTable.IsEmpty()|];
+        i := MyTable.[|Count()|];
+        b := MyTable.[|IsEmpty()|];
     end;
 }
 

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0078/HasDiagnostic/TempVar.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0078/HasDiagnostic/TempVar.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        [|MyTable.Validate(MyField, 1)|];
+        [|MyTable.Insert(true)|];
+        [|MyTable.Modify(true)|];
+        [|MyTable.Delete(true)|];
+        [|MyTable.DeleteAll(true)|];
+        [|MyTable.ModifyAll(MyField, 1, true)|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempTable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempTable.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.Validate(MyField, 1)|];
+        [|MyTable.Insert(true)|];
+        [|MyTable.Modify(true)|];
+        [|MyTable.Delete(true)|];
+        [|MyTable.DeleteAll(true)|];
+        [|MyTable.ModifyAll(MyField, 1, true)|];
+    end;
+}
+
+table 50100 MyTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempTableExplicitTemp.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempTableExplicitTemp.al
@@ -1,0 +1,24 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        [|MyTable.Validate(MyField, 1)|];
+        [|MyTable.Insert(true)|];
+        [|MyTable.Modify(true)|];
+        [|MyTable.Delete(true)|];
+        [|MyTable.DeleteAll(true)|];
+        [|MyTable.ModifyAll(MyField, 1, true)|];
+    end;
+}
+
+table 50100 MyTable
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempVarExplicit.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempVarExplicit.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        [|MyTable.MyField := 1|];
+        [|MyTable.Insert(false)|];
+        [|MyTable.Modify(false)|];
+        [|MyTable.Delete(false)|];
+        [|MyTable.DeleteAll(false)|];
+        [|MyTable.ModifyAll(MyField, 1, false)|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempVarImplicit.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0078/NoDiagnostic/TempVarImplicit.al
@@ -1,0 +1,22 @@
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        MyTable: Record MyTable temporary;
+    begin
+        [|MyTable.MyField := 1|];
+        [|MyTable.Insert()|];
+        [|MyTable.Modify()|];
+        [|MyTable.Delete()|];
+        [|MyTable.DeleteAll()|];
+        [|MyTable.ModifyAll(MyField, 1)|];
+    end;
+}
+
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0079/HasDiagnostic/PublicEvent.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0079/HasDiagnostic/PublicEvent.al
@@ -1,0 +1,22 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    [BusinessEvent(true)]
+    procedure [|MyProcedure|]()
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    procedure [|MyProcedure2|]()
+    begin
+    end;
+
+    [InternalEvent(false)]
+    procedure [|MyProcedure3|]()
+    begin
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0079/NoDiagnostic/InternalEvent.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0079/NoDiagnostic/InternalEvent.al
@@ -1,0 +1,22 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    [BusinessEvent(true)]
+    internal procedure [|MyProcedure|]()
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    internal procedure [|MyProcedure2|]()
+    begin
+    end;
+
+    [InternalEvent(false)]
+    internal procedure [|MyProcedure3|]()
+    begin
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0079/NoDiagnostic/LocalEvent.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0079/NoDiagnostic/LocalEvent.al
@@ -1,0 +1,22 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    [BusinessEvent(true)]
+    local procedure [|MyProcedure|]()
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure [|MyProcedure2|]()
+    begin
+    end;
+
+    [InternalEvent(false)]
+    local procedure [|MyProcedure3|]()
+    begin
+    end;
+}

--- a/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
@@ -34,9 +34,10 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
         if (!operation.Syntax.GetLastToken().IsKind(SyntaxKind.CloseParenToken) &&
             MethodsRequiringParenthesis.Contains(method.Name))
         {
+            var location = operation.Syntax.GetIdentifierNameSyntax()?.GetLocation() ?? operation.Syntax.GetLocation();
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.Rule0077MissingParenthesis,
-                ctx.Operation.Syntax.GetIdentifierNameSyntax().GetLocation(),
+                location,
                 method.Name));
         }
     }

--- a/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
@@ -31,8 +31,8 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
             operation.TargetMethod is not IMethodSymbol { MethodKind: MethodKind.BuiltInMethod } method)
             return;
 
-        if (!operation.Syntax.GetLastToken().IsKind(SyntaxKind.CloseParenToken) &&
-            MethodsRequiringParenthesis.Contains(method.Name))
+        if (MethodsRequiringParenthesis.Contains(method.Name) &&
+            !operation.Syntax.GetLastToken().IsKind(SyntaxKind.CloseParenToken))
         {
             var location = operation.Syntax.GetIdentifierNameSyntax()?.GetLocation() ?? operation.Syntax.GetLocation();
             ctx.ReportDiagnostic(Diagnostic.Create(

--- a/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using System.Collections.Immutable;
+using BusinessCentral.LinterCop.AnalysisContextExtension;
+
+namespace BusinessCentral.LinterCop.Design;
+
+[DiagnosticAnalyzer]
+public class Rule0077MissingParenthesis : DiagnosticAnalyzer
+{
+    private static readonly ImmutableHashSet<string> MethodsRequiringParenthesis = ImmutableHashSet.Create(
+        "Count",
+        "IsEmpty"
+    );
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create<DiagnosticDescriptor>(DiagnosticDescriptors.Rule0077MissingParenthesis);
+
+    public override void Initialize(AnalysisContext context) => 
+        context.RegisterOperationAction(AnalyzeParenthesis, OperationKind.InvocationExpression);
+
+    private void AnalyzeParenthesis(OperationAnalysisContext ctx)
+    {
+        if (ctx.IsObsoletePendingOrRemoved())
+            return;
+
+        if (ctx.Operation is not IInvocationExpression { Arguments.Length: 0 } operation ||
+            operation.TargetMethod is not IMethodSymbol { MethodKind: MethodKind.BuiltInMethod } method)
+            return;
+
+        if (!operation.Syntax.GetLastToken().IsKind(SyntaxKind.CloseParenToken) &&
+            MethodsRequiringParenthesis.Contains(method.Name))
+        {
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.Rule0077MissingParenthesis,
+                ctx.Operation.Syntax.GetLocation(),
+                method.Name));
+        }
+    }
+
+    private static class DiagnosticDescriptors
+    {
+        public static readonly DiagnosticDescriptor Rule0077MissingParenthesis = new(
+            id: LinterCopAnalyzers.AnalyzerPrefix + "0077",
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0077MissingParenthesisTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0077MissingParenthesisFormat"),
+            category: "Design",
+            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: LinterCopAnalyzers.GetLocalizableString("Rule0077MissingParenthesisDescription"),
+            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0077");
+    }    
+}

--- a/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
@@ -11,7 +11,10 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
 {
     private static readonly ImmutableHashSet<string> MethodsRequiringParenthesis = ImmutableHashSet.Create(
         "Count",
-        "IsEmpty"
+        "IsEmpty",
+        "Today",
+        "WorkDate",
+        "GuiAllowed"
     );
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create<DiagnosticDescriptor>(DiagnosticDescriptors.Rule0077MissingParenthesis);
@@ -38,7 +41,7 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
         }
     }
 
-    private static class DiagnosticDescriptors
+    public static class DiagnosticDescriptors
     {
         public static readonly DiagnosticDescriptor Rule0077MissingParenthesis = new(
             id: LinterCopAnalyzers.AnalyzerPrefix + "0077",

--- a/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
@@ -36,7 +36,7 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
         {
             ctx.ReportDiagnostic(Diagnostic.Create(
                 DiagnosticDescriptors.Rule0077MissingParenthesis,
-                ctx.Operation.Syntax.GetLocation(),
+                ctx.Operation.Syntax.GetIdentifierNameSyntax().GetLocation(),
                 method.Name));
         }
     }

--- a/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
@@ -19,7 +19,7 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create<DiagnosticDescriptor>(DiagnosticDescriptors.Rule0077MissingParenthesis);
 
-    public override void Initialize(AnalysisContext context) => 
+    public override void Initialize(AnalysisContext context) =>
         context.RegisterOperationAction(AnalyzeParenthesis, OperationKind.InvocationExpression);
 
     private void AnalyzeParenthesis(OperationAnalysisContext ctx)
@@ -51,5 +51,5 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
             defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
             description: LinterCopAnalyzers.GetLocalizableString("Rule0077MissingParenthesisDescription"),
             helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0077");
-    }    
+    }
 }

--- a/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0077MissingParenthesis.cs
@@ -48,7 +48,7 @@ public class Rule0077MissingParenthesis : DiagnosticAnalyzer
             title: LinterCopAnalyzers.GetLocalizableString("Rule0077MissingParenthesisTitle"),
             messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0077MissingParenthesisFormat"),
             category: "Design",
-            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            defaultSeverity: DiagnosticSeverity.Info, isEnabledByDefault: true,
             description: LinterCopAnalyzers.GetLocalizableString("Rule0077MissingParenthesisDescription"),
             helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0077");
     }

--- a/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
@@ -54,11 +54,11 @@ public class Rule0078TemporaryRecordsShouldNotTriggerTableTriggers : DiagnosticA
     {
         public static readonly DiagnosticDescriptor Rule0078TemporaryRecordsShouldNotTriggerTableTriggers = new(
             id: LinterCopAnalyzers.AnalyzerPrefix + "0078",
-            title: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsShouldNotTriggerTableTriggersTitle"),
-            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsShouldNotTriggerTableTriggersFormat"),
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsFormat"),
             category: "Design",
             defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
-            description: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsShouldNotTriggerTableTriggersDescription"),
+            description: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsDescription"),
             helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0078");
     }
 }

--- a/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
@@ -1,0 +1,65 @@
+﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+using CompanialCopAnalyzer.Design.Helper;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace BusinessCentral.LinterCop.Design;
+
+[DiagnosticAnalyzer]
+public class Rule0078TemporaryRecordsShouldNotTriggerTableTriggers : DiagnosticAnalyzer
+{
+    private static readonly HashSet<string> methodsToCheck = new() { "Insert", "Modify", "Delete", "DeleteAll", "Validate", "ModifyAll" };
+    private static readonly string validateMethod = "Validate";
+    private static readonly string modifyAllMethod = "ModifyAll";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers);
+
+    public override void Initialize(AnalysisContext context) =>
+        context.RegisterOperationAction(AnalyzeTemporaryRecords, OperationKind.InvocationExpression);
+
+    private void AnalyzeTemporaryRecords(OperationAnalysisContext ctx)
+    {
+        if (ctx.IsObsoletePendingOrRemoved())
+            return;
+
+        var invocationExpression = (IInvocationExpression)ctx.Operation;
+        if (!methodsToCheck.Contains(invocationExpression.TargetMethod.Name))
+            return;
+
+        if (!(invocationExpression.Instance?.Type is IRecordTypeSymbol record) || !record.Temporary)
+            return;
+
+        bool isExecutingTriggersOrValidation = invocationExpression.TargetMethod.Name switch
+        {
+            validateMethod => true,
+            modifyAllMethod => invocationExpression.Arguments.Length == 3 &&
+                               IsRunTriggerEnabled(invocationExpression.Arguments[2]),
+            _ => invocationExpression.Arguments.Length == 1 &&
+                 IsRunTriggerEnabled(invocationExpression.Arguments[0])
+        };
+
+        if (isExecutingTriggersOrValidation)
+        {
+            ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers,
+                ctx.Operation.Syntax.GetLocation()));
+        }
+    }
+
+    private static bool IsRunTriggerEnabled(IArgument argument) =>
+        argument.Value.ConstantValue.HasValue &&
+        argument.Value.ConstantValue.Value is bool isEnabled &&
+        isEnabled;
+
+    public static class DiagnosticDescriptors
+    {
+        public static readonly DiagnosticDescriptor Rule0078TemporaryRecordsShouldNotTriggerTableTriggers = new(
+            id: LinterCopAnalyzers.AnalyzerPrefix + "0078",
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsShouldNotTriggerTableTriggersTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsShouldNotTriggerTableTriggersFormat"),
+            category: "Design",
+            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsShouldNotTriggerTableTriggersDescription"),
+            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0078");
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
@@ -24,7 +24,9 @@ public class Rule0078TemporaryRecordsShouldNotTriggerTableTriggers : DiagnosticA
         if (!methodsToCheck.Contains(invocationExpression.TargetMethod.Name))
             return;
 
-        if (!(invocationExpression.Instance?.Type is IRecordTypeSymbol record) || !record.Temporary)
+        if (invocationExpression.Instance?.Type is not IRecordTypeSymbol record ||
+            !record.Temporary ||
+            record.BaseTable.TableType == TableTypeKind.Temporary)
             return;
 
         bool isExecutingTriggersOrValidation = invocationExpression.TargetMethod.Name switch

--- a/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
@@ -58,7 +58,7 @@ public class Rule0078TemporaryRecordsShouldNotTriggerTableTriggers : DiagnosticA
             title: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsTitle"),
             messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsFormat"),
             category: "Design",
-            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            defaultSeverity: DiagnosticSeverity.Info, isEnabledByDefault: true,
             description: LinterCopAnalyzers.GetLocalizableString("Rule0078TemporaryRecordsDescription"),
             helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0078");
     }

--- a/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
@@ -1,5 +1,4 @@
 ﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
-using CompanialCopAnalyzer.Design.Helper;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
@@ -10,8 +9,6 @@ namespace BusinessCentral.LinterCop.Design;
 public class Rule0078TemporaryRecordsShouldNotTriggerTableTriggers : DiagnosticAnalyzer
 {
     private static readonly HashSet<string> methodsToCheck = new() { "Insert", "Modify", "Delete", "DeleteAll", "Validate", "ModifyAll" };
-    private static readonly string validateMethod = "Validate";
-    private static readonly string modifyAllMethod = "ModifyAll";
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers);
 
@@ -32,9 +29,9 @@ public class Rule0078TemporaryRecordsShouldNotTriggerTableTriggers : DiagnosticA
 
         bool isExecutingTriggersOrValidation = invocationExpression.TargetMethod.Name switch
         {
-            validateMethod => true,
-            modifyAllMethod => invocationExpression.Arguments.Length == 3 &&
-                               IsRunTriggerEnabled(invocationExpression.Arguments[2]),
+            "Validate" => true,
+            "ModifyAll" => invocationExpression.Arguments.Length == 3 &&
+                          IsRunTriggerEnabled(invocationExpression.Arguments[2]),
             _ => invocationExpression.Arguments.Length == 1 &&
                  IsRunTriggerEnabled(invocationExpression.Arguments[0])
         };

--- a/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0078TempRecRunTrigger.cs
@@ -20,7 +20,8 @@ public class Rule0078TemporaryRecordsShouldNotTriggerTableTriggers : DiagnosticA
         if (ctx.IsObsoletePendingOrRemoved())
             return;
 
-        var invocationExpression = (IInvocationExpression)ctx.Operation;
+        if (ctx.Operation is not IInvocationExpression invocationExpression)
+            return;
         if (!methodsToCheck.Contains(invocationExpression.TargetMethod.Name))
             return;
 

--- a/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
@@ -32,7 +32,7 @@ public class Rule0079NonPublicEventPublisher : DiagnosticAnalyzer
             title: LinterCopAnalyzers.GetLocalizableString("Rule0079NonPublicEventPublisherTitle"),
             messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0079NonPublicEventPublisherFormat"),
             category: "Design",
-            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            defaultSeverity: DiagnosticSeverity.Info, isEnabledByDefault: true,
             description: LinterCopAnalyzers.GetLocalizableString("Rule0079NonPublicEventPublisherDescription"),
             helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0079");
     }

--- a/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
@@ -1,0 +1,40 @@
+﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
+using CompanialCopAnalyzer.Design.Helper;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+namespace BusinessCentral.LinterCop.Design;
+
+[DiagnosticAnalyzer]
+public class Rule0079NonPublicEventPublisher : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.Rule0079NonPublicEventPublisher);
+
+    public override void Initialize(AnalysisContext context) => 
+        context.RegisterSymbolAction(AnalyzeEventPublisher, SymbolKind.Method);
+
+    private void AnalyzeEventPublisher(SymbolAnalysisContext ctx)
+    {
+        if (ctx.IsObsoletePendingOrRemoved())
+            return;
+
+        if (ctx.Symbol is not IMethodSymbol symbol || !symbol.IsEvent)
+            return;
+
+        if (!symbol.IsLocal && !symbol.IsInternal)
+            ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0079NonPublicEventPublisher, symbol.GetLocation()));
+    }
+
+    public static class DiagnosticDescriptors
+    {
+        public static readonly DiagnosticDescriptor Rule0079NonPublicEventPublisher = new(
+            id: LinterCopAnalyzers.AnalyzerPrefix + "0079",
+            title: LinterCopAnalyzers.GetLocalizableString("Rule0079NonPublicEventPublisherTitle"),
+            messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0079NonPublicEventPublisherFormat"),
+            category: "Design",
+            defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true,
+            description: LinterCopAnalyzers.GetLocalizableString("Rule0079NonPublicEventPublisherDescription"),
+            helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0079");
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
@@ -1,5 +1,4 @@
 ﻿using BusinessCentral.LinterCop.AnalysisContextExtension;
-using CompanialCopAnalyzer.Design.Helper;
 using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;

--- a/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0079NonPublicEventPublisher.cs
@@ -10,7 +10,7 @@ public class Rule0079NonPublicEventPublisher : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(DiagnosticDescriptors.Rule0079NonPublicEventPublisher);
 
-    public override void Initialize(AnalysisContext context) => 
+    public override void Initialize(AnalysisContext context) =>
         context.RegisterSymbolAction(AnalyzeEventPublisher, SymbolKind.Method);
 
     private void AnalyzeEventPublisher(SymbolAnalysisContext ctx)

--- a/BusinessCentral.LinterCop/LinterCop.ruleset.json
+++ b/BusinessCentral.LinterCop/LinterCop.ruleset.json
@@ -371,6 +371,21 @@
       "id": "LC0074",
       "action": "Warning",
       "justification": "Set values for FlowFilter fields using filtering methods."
-    }
+    },
+    {
+      "id": "LC0077",
+      "action": "Warning",
+      "justification": "Methods that require parenthesis should always be called with parenthesis."
+    },
+    {
+      "id": "LC0078",
+      "action": "Warning",
+      "justification": "Temporary records should not trigger table triggers."
+    },
+    {
+      "id": "LC0079",
+      "action": "Warning",
+      "justification": "Event publishers should not be public."
+    }    
   ]
 }

--- a/BusinessCentral.LinterCop/LinterCop.ruleset.json
+++ b/BusinessCentral.LinterCop/LinterCop.ruleset.json
@@ -384,17 +384,17 @@
     },
     {
       "id": "LC0077",
-      "action": "Warning",
+      "action": "Info",
       "justification": "Methods that require parenthesis should always be called with parenthesis."
     },
     {
       "id": "LC0078",
-      "action": "Warning",
+      "action": "Info",
       "justification": "Temporary records should not trigger table triggers."
     },
     {
       "id": "LC0079",
-      "action": "Warning",
+      "action": "Info",
       "justification": "Event publishers should not be public."
     }    
   ]

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -804,31 +804,31 @@
   <data name="Rule0076TableRelationTooLongDescription" xml:space="preserve">
     <value>The field with table relation should have at least the same length as the referenced field.</value>
   </data>  
-  <data name="Rule0077MissingParenthesisDescription" xml:space="preserve">
-    <value>You must specify open and close parenthesis after '{0}'</value>
+  <data name="Rule0077MissingParenthesisTitle" xml:space="preserve">
+    <value>Function calls should have parenthesis even if they do not have any parameters.</value>
   </data>
   <data name="Rule0077MissingParenthesisFormat" xml:space="preserve">
     <value>You must specify open and close parenthesis after '{0}'</value>
   </data>
-  <data name="Rule0077MissingParenthesisTitle" xml:space="preserve">
-    <value>Function calls should have parenthesis even if they do not have any parameters.</value>
+  <data name="Rule0077MissingParenthesisDescription" xml:space="preserve">
+    <value>You must specify open and close parenthesis after '{0}'</value>
   </data>
-  <data name="Rule0078TemporaryRecordsDescription" xml:space="preserve">
+  <data name="Rule0078TemporaryRecordsTitle" xml:space="preserve">
     <value>Temporary records should not trigger the table triggers.</value>
   </data>
   <data name="Rule0078TemporaryRecordsFormat" xml:space="preserve">
     <value>Temporary records should not trigger the table triggers.</value>
   </data>
-  <data name="Rule0078TemporaryRecordsTitle" xml:space="preserve">
+  <data name="Rule0078TemporaryRecordsDescription" xml:space="preserve">
     <value>Temporary records should not trigger the table triggers.</value>
-  </data>  
-  <data name="Rule0079NonPublicEventPublisherDescription" xml:space="preserve">
+  </data>
+  <data name="Rule0079NonPublicEventPublisherTitle" xml:space="preserve">
     <value>Event Publishers should be local or internal to allow for future parameter extensions.</value>
   </data>
   <data name="Rule0079NonPublicEventPublisherFormat" xml:space="preserve">
     <value>Event Publishers should be local or internal to allow for future parameter extensions.</value>
   </data>
-  <data name="Rule0079NonPublicEventPublisherTitle" xml:space="preserve">
+  <data name="Rule0079NonPublicEventPublisherDescription" xml:space="preserve">
     <value>Event Publishers should be local or internal to allow for future parameter extensions.</value>
   </data>
 </root>

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -786,4 +786,31 @@
   <data name="Rule0074FlowFilterAssignmentDescription" xml:space="preserve">
     <value>Directly assigning values to FlowFilter fields bypasses their purpose and invalidates the filtering logic, resulting in incorrect or unintended calculations. Instead, use the .SetFilter() or .SetRange() methods to define the appropriate filters.</value>
   </data>
+  <data name="Rule0077MissingParenthesisDescription" xml:space="preserve">
+    <value>You must specify open and close parenthesis after '{0}'</value>
+  </data>
+  <data name="Rule0077MissingParenthesisFormat" xml:space="preserve">
+    <value>You must specify open and close parenthesis after '{0}'</value>
+  </data>
+  <data name="Rule0077MissingParenthesisTitle" xml:space="preserve">
+    <value>Function calls should have parenthesis even if they do not have any parameters.</value>
+  </data>
+  <data name="Rule0078TemporaryRecordsDescription" xml:space="preserve">
+    <value>Temporary records should not trigger the table triggers.</value>
+  </data>
+  <data name="Rule0078TemporaryRecordsFormat" xml:space="preserve">
+    <value>Temporary records should not trigger the table triggers.</value>
+  </data>
+  <data name="Rule0078TemporaryRecordsTitle" xml:space="preserve">
+    <value>Temporary records should not trigger the table triggers.</value>
+  </data>  
+  <data name="Rule0079NonPublicEventPublisherDescription" xml:space="preserve">
+    <value>Event Publishers should be local or internal to allow for future parameter extensions.</value>
+  </data>
+  <data name="Rule0079NonPublicEventPublisherFormat" xml:space="preserve">
+    <value>Event Publishers should be local or internal to allow for future parameter extensions.</value>
+  </data>
+  <data name="Rule0079NonPublicEventPublisherTitle" xml:space="preserve">
+    <value>Event Publishers should be local or internal to allow for future parameter extensions.</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -228,3 +228,6 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 |[LC0072](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0072)|The documentation comment must match the procedure syntax.|Info|
 |[LC0073](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0073)|Handled parameters in event signatures should be passed by var.|Warning|
 |[LC0074](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0074)|Set values for FlowFilter fields using filtering methods.|Warning|
+|[LC0077](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0077)|Methods  should always be called with parenthesis.|Warning|
+|[LC0078](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0078)|Temporary records should not trigger table triggers.|Warning|
+|[LC0079](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0079)|Event publishers should not be public.|Warning|

--- a/README.md
+++ b/README.md
@@ -230,6 +230,6 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 |[LC0074](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0074)|Set values for FlowFilter fields using filtering methods.|Warning|
 |[LC0075](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0075)|Incorrect number or type of arguments in `.Get()` method on Record object.|Warning|13.0
 |[LC0076](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0076)|The field with table relation should have at least the same length as the referenced field.|Warning|
-|[LC0077](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0077)|Methods  should always be called with parenthesis.|Warning|
-|[LC0078](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0078)|Temporary records should not trigger table triggers.|Warning|
-|[LC0079](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0079)|Event publishers should not be public.|Warning|
+|[LC0077](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0077)|Methods  should always be called with parenthesis.|Info|
+|[LC0078](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0078)|Temporary records should not trigger table triggers.|Info|
+|[LC0079](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0079)|Event publishers should not be public.|Info|


### PR DESCRIPTION
This PR introduces three new rules that were part of the discussion here:
https://github.com/StefanMaron/BusinessCentral.LinterCop/discussions/776

### Missing brackets
If a procedure is missing brackets, there's a standard rule that throws a warning, however, some internal methods are not covered by that rule. This rule introduces a warning for a few more of the most common cases (Today, WorkDate, GuiAllowed, IsEmpty, Count)

This list could be extended further; I could use some input on that front.

### Triggers on Temporary Records
When triggers are executed on a temporary record variable, the temporary scope no longer applies to any code in those triggers and can lead to unwanted database changes. This rule introduces a warning that triggers (Insert, Modify, Delete, DeleteAll, ModifyAll) and Validate should not be executed on temporary record variables.

The rule does not throw a warning if the table itself is of type temporary, as it's expected that its triggers are created safely.

### Non-Public Event Publisher
When an event publisher is declared as public, you cannot add parameters to it, as AppSourceCop treats it as a breaking change to a public API. Local and Internal publishers on the other hand do not have this issue. In order to keep the option of extending the publishers later, the events should be declared as either local or internal