### PR TITLE
Resolve false positive on spaces in parameter name on Rule0072

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0072CheckProcedureDocumentationComment.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0072CheckProcedureDocumentationComment.cs
@@ -38,7 +38,7 @@ public class Rule0072CheckProcedureDocumentationComment : DiagnosticAnalyzer
             {
                 case "param":
                     var nameAttribute = (XmlNameAttributeSyntax)element.StartTag.Attributes.First(att => att.IsKind(SyntaxKind.XmlNameAttribute));
-                    var parameterName = nameAttribute.Identifier.Identifier.ValueText;
+                    var parameterName = nameAttribute.Identifier.GetText().ToString();
                     if (!docCommentParameters.ContainsKey(parameterName))
                         docCommentParameters.Add(parameterName, element);
                     break;


### PR DESCRIPTION
Fixes: https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/889