### PR TITLE
Resolve diagnostic message on System.Date2DMY(Date, Integer) Method

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0083BuiltInDateTimeMethod.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0083BuiltInDateTimeMethod.cs
@@ -57,7 +57,7 @@ public class Rule0083BuiltInDateTimeMethod : DiagnosticAnalyzer
             1 => "Day()",
             2 => "Month()",
             3 => "Year()",
-            _ => "<Day/Month/Year>"
+            _ => null
         };
     }
 
@@ -71,8 +71,9 @@ public class Rule0083BuiltInDateTimeMethod : DiagnosticAnalyzer
         return formatSpecifier switch
         {
             1 => "DayOfWeek()",
-            2 => "Year()",
-            _ => "<DayOfWeek/Year>"
+            2 => "WeekNo()",
+            3 => "Year()",
+            _ => null
         };
     }
 
@@ -87,7 +88,7 @@ public class Rule0083BuiltInDateTimeMethod : DiagnosticAnalyzer
             "<MINUTES>" => "Minute()",
             "<SECONDS>" => "Second()",
             "<THOUSANDS>" => "Millisecond()",
-            _ => string.Empty
+            _ => null
         };
     }
 }


### PR DESCRIPTION
I had based the rule on the table of the in the changelog, we're an mistake was made.

![image](https://github.com/user-attachments/assets/028d5942-0250-4c08-a8ee-638152a96101)
https://marketplace.visualstudio.com/items/ms-dynamics-smb.al/changelog

The suggestion of the diagnostic was wrong, where this PR fixes this.

Type | New method | Existing | Description
-- | -- | -- | --
Date | MyDate.DayOfWeek() | Date2DWY(MyDate, 1) | Gets the day of week from MyDate
Date | MyDate.WeekNo() | Date2DWY(MyDate, 2) | Gets the week number from MyDate
Date | MyDate.Year() | Date2DWY(MyDate, 3) | Gets the year from MyDate

