### PR TITLE
LC0068: fix permissions interrupted by pragmas or comments

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -41,6 +41,9 @@ public class Rule0068
 #endif
     // [TestCase("IntegerTable")]
     [TestCase("XMLPortWithTableElementProps")]
+    [TestCase("PermissionsAsObjectId")]
+    [TestCase("PermissionPropertyWithPragma")]
+    [TestCase("PermissionPropertyWithComment")] 
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PermissionPropertyWithComment.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PermissionPropertyWithComment.al
@@ -1,0 +1,32 @@
+codeunit 50000 CommentTestCodeunit
+{
+    Permissions =
+        tabledata MyTableOne = r,
+        // single line comment
+        tabledata MyTableTwo = r;
+
+    trigger OnRun()
+    var
+        MyTableOne: Record MyTableOne;
+        MyTableTwo: Record MyTableTwo;
+    begin
+        MyTableOne.FindFirst();
+        [|MyTableTwo.FindFirst();|]
+    end;
+}
+
+table 50000 MyTableOne
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50001 MyTableTwo
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PermissionPropertyWithPragma.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PermissionPropertyWithPragma.al
@@ -1,0 +1,45 @@
+codeunit 50000 PragmaTestCodeunit
+{
+    // example from issue #923 (pragma in permissions property)
+
+    Permissions =
+        tabledata MyTableOne = r,
+#pragma warning disable AA0123
+        tabledata MyTableTwo = r,
+#pragma warning restore AA0123
+        tabledata MyTableThree = r;
+
+    trigger OnRun()
+    var
+        MyTableOne: Record MyTableOne;
+        MyTableTwo: Record MyTableTwo;
+        MyTableThree: Record MyTableThree;
+    begin
+        MyTableOne.FindFirst();
+        [|MyTableTwo.FindFirst();|]
+        [|MyTableThree.FindFirst();|]
+    end;
+}
+table 50000 MyTableOne
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50001 MyTableTwo
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50002 MyTableThree
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PermissionsAsObjectId.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PermissionsAsObjectId.al
@@ -1,0 +1,19 @@
+codeunit 50000 MyCodeunit
+{
+    Permissions = tabledata 50000 = r;
+
+    trigger OnRun()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.FindFirst();|]
+    end;
+}
+
+table 50000 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -4,6 +4,7 @@ using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Utilities;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace BusinessCentral.LinterCop.Design;
 
@@ -203,45 +204,35 @@ public class Rule0068CheckObjectPermission : DiagnosticAnalyzer
         }
 
         bool permissionContainRequestedObject = false;
-
-        foreach (var permission in objectPermissions.Value.ToString().ToLowerInvariant().Split(','))
+        var permissions = objectPermissions.GetPropertyValueSyntax<PermissionPropertyValueSyntax>();
+        foreach (var permission in permissions.PermissionProperties)
         {
-            var parts = permission.Trim().Split(new[] { '=' }, 2);
-            if (parts.Length != 2)
+            if (!permission.ObjectType.IsKind(SyntaxKind.TableDataKeyword))
+                continue; // ensure permission is tabledata
+
+            var identifier = permission.ObjectReference.Identifier;
+            switch (identifier.Kind)
             {
-                // Handle invalid permission format
-                continue;
+                case SyntaxKind.IdentifierName:
+                    string name = ((IdentifierNameSyntax)identifier).Identifier.ValueText.UnquoteIdentifier();
+                    if (name.Equals(variableType.Name, StringComparison.OrdinalIgnoreCase))
+                        permissionContainRequestedObject = true;
+                    break;
+                case SyntaxKind.ObjectId:
+                    int objectId = Convert.ToInt32(((ObjectIdSyntax)identifier).Value.ValueText);
+                    if (objectId == targetTable.Id)
+                        permissionContainRequestedObject = true;
+                    break;
+                case SyntaxKind.QualifiedName:
+                    string qualifier = ((QualifiedNameSyntax)identifier).Left.GetText().ToString();
+                    string onlyName = ((QualifiedNameSyntax)identifier).Right.Identifier.ValueText.UnquoteIdentifier();
+                    if (qualifier.Equals(variableType.OriginalDefinition.ContainingNamespace?.QualifiedName, StringComparison.OrdinalIgnoreCase) && onlyName.Equals(variableType.Name, StringComparison.OrdinalIgnoreCase))
+                        permissionContainRequestedObject = true;
+                    break;
             }
-
-            var typeAndObjectName = parts[0].Trim();
-            var permissionValue = parts[1].Trim();
-
-            // Extract type and object name, handling quoted object names
-            var typeEndIndex = typeAndObjectName.IndexOf(' ');
-            if (typeEndIndex == -1)
+            if (permissionContainRequestedObject && !permission.Permissions.ValueText.ToLowerInvariant().Contains(requestedPermission))
             {
-                // Handle invalid type/object name format
-                continue;
-            }
-
-            var type = typeAndObjectName[..typeEndIndex].Trim();
-            var objectName = typeAndObjectName[typeEndIndex..].Trim().Trim('"');
-
-            bool nameSpaceNameMatch = false;
-#if !LessThenFall2023RV1
-            nameSpaceNameMatch = objectName.UnquoteIdentifier() == (variableType.OriginalDefinition.ContainingNamespace?.QualifiedName.ToLowerInvariant() + "." + variableType.Name.ToLowerInvariant());
-#endif
-
-            // Match against the parameters of the procedure
-            if (type == "tabledata" && (objectName == variableType.Name.ToLowerInvariant() || nameSpaceNameMatch))
-            {
-                permissionContainRequestedObject = true;
-                // Handle tabledata permissions
-                var permissions = permissionValue.ToCharArray();
-                if (!permissions.Contains(requestedPermission))
-                {
-                    ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0068CheckObjectPermission, location, requestedPermission, variableType.Name));
-                }
+                ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0068CheckObjectPermission, location, requestedPermission, variableType.Name));
             }
         }
         if (!permissionContainRequestedObject)

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -230,9 +230,11 @@ public class Rule0068CheckObjectPermission : DiagnosticAnalyzer
                         permissionContainRequestedObject = true;
                     break;
             }
-            if (permissionContainRequestedObject && !permission.Permissions.ValueText.ToLowerInvariant().Contains(requestedPermission))
+            if (permissionContainRequestedObject)
             {
-                ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0068CheckObjectPermission, location, requestedPermission, variableType.Name));
+                var permissionsText = permission.Permissions.ValueText;
+                if (permissionsText is null || !permissionsText.ToLowerInvariant().Contains(requestedPermission))
+                    ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0068CheckObjectPermission, location, requestedPermission, variableType.Name));
             }
         }
         if (!permissionContainRequestedObject)


### PR DESCRIPTION
Fixes #923.

Replaces the string based analysis of the whole permissions property text with individual analysis of the `PermissionPropertyValueSyntax`'s `PermissionProperties`.
With this change permissions by object id will also be analysed correctly (though they shouldn't be used according to the other rules).