### PR TITLE
LC0068: Assert permissions for page extension source table

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -36,6 +36,7 @@ public class Rule0068
     [TestCase("ProcedureCallsInherentPermissionsProperty")]
     [TestCase("ProcedureCallsInherentPermissionsAttribute")]
     [TestCase("PageSourceTable")]
+    [TestCase("PageExtensionSourceTable")]
 #if !LessThenFall2023RV1
     [TestCase("ProcedureCallsPermissionsPropertyFullyQualified")]
 #endif

--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -36,7 +36,9 @@ public class Rule0068
     [TestCase("ProcedureCallsInherentPermissionsProperty")]
     [TestCase("ProcedureCallsInherentPermissionsAttribute")]
     [TestCase("PageSourceTable")]
+#if !LessThenSpring2024
     [TestCase("PageExtensionSourceTable")]
+#endif
 #if !LessThenFall2023RV1
     [TestCase("ProcedureCallsPermissionsPropertyFullyQualified")]
 #endif

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PageExtensionSourceTable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/PageExtensionSourceTable.al
@@ -1,0 +1,25 @@
+pageextension 50000 MyPageExtension extends MyPage
+{
+    trigger OnOpenPage()
+    var
+        MyTable: Record MyTable;
+    begin
+        [|MyTable.FindFirst();|]
+        [|MyTable.Insert();|]
+        [|MyTable.Modify();|]
+        [|MyTable.Delete();|]
+    end;
+}
+
+page 50000 MyPage
+{
+    SourceTable = MyTable;
+}
+
+table 50000 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -116,13 +116,8 @@ public class Rule0068CheckObjectPermission : DiagnosticAnalyzer
 
         ITableTypeSymbol targetTable = (ITableTypeSymbol)((IRecordTypeSymbol)variableType).OriginalDefinition;
 
-        if (ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol()?.NavTypeKind == NavTypeKind.Page)
-        {
-            IPropertySymbol? sourceTableProperty = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol()?.GetProperty(PropertyKind.SourceTable);
-            if (sourceTableProperty is not null)
-                if (sourceTableProperty.Value == targetTable)
-                    return;
-        }
+        if (TargetTableIsPageSourceTable(ctx, targetTable))
+            return;
 
         if (variableType.ToString().ToLower().EndsWith("temporary") || (targetTable.TableType == TableTypeKind.Temporary)) return;
 
@@ -259,6 +254,30 @@ public class Rule0068CheckObjectPermission : DiagnosticAnalyzer
         if (permissions is not null && permissions.Contains(requestedPermission.ToString().ToLowerInvariant()[0]))
             return true;
 
+        return false;
+    }
+
+    private bool TargetTableIsPageSourceTable(OperationAnalysisContext ctx, ITableTypeSymbol targetTable)
+    {
+        var applicationObjectTypeSymbol = ctx.ContainingSymbol.GetContainingApplicationObjectTypeSymbol();
+        if (applicationObjectTypeSymbol is not null)
+        {
+            IPropertySymbol? sourceTableProperty = null;
+            switch (applicationObjectTypeSymbol.GetNavTypeKindSafe())
+            {
+                case NavTypeKind.Page:
+                    sourceTableProperty = applicationObjectTypeSymbol.GetProperty(PropertyKind.SourceTable);
+                    break;
+                case NavTypeKind.PageExtension:
+                    var extendedPageSymbol = ((IPageExtensionTypeSymbol)applicationObjectTypeSymbol).Target;
+                    if (extendedPageSymbol is not null)
+                        sourceTableProperty = extendedPageSymbol.GetProperty(PropertyKind.SourceTable);
+                    break;
+            }
+            if (sourceTableProperty is not null)
+                if (sourceTableProperty.Value == targetTable)
+                    return true;
+        }
         return false;
     }
 }


### PR DESCRIPTION
Fixes #942.

Applies to same logic that was introduced for issue #728 to pages also to their page extensions.