### PR TITLE
Tests: Enable analysis of multiple test markers in a test file

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0001.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0001.cs
@@ -19,7 +19,7 @@ public class Rule0001
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0001FlowFieldsShouldNotBeEditable>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0001FlowFieldsShouldNotBeEditable.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0001FlowFieldsShouldNotBeEditable.Id);
     }
 
     [Test]
@@ -34,6 +34,6 @@ public class Rule0001
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0001FlowFieldsShouldNotBeEditable>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0001FlowFieldsShouldNotBeEditable.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0001FlowFieldsShouldNotBeEditable.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0002.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0002.cs
@@ -19,7 +19,7 @@ public class Rule0002
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0002CommitMustBeExplainedByComment>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0002CommitMustBeExplainedByComment.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0002CommitMustBeExplainedByComment.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0002
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0002CommitMustBeExplainedByComment>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0002CommitMustBeExplainedByComment.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0002CommitMustBeExplainedByComment.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0003.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0003.cs
@@ -19,7 +19,7 @@ public class Rule0003
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0003DoNotUseObjectIDsInVariablesOrProperties>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0003DoNotUseObjectIDsInVariablesOrProperties.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0003DoNotUseObjectIDsInVariablesOrProperties.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0003
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0003DoNotUseObjectIDsInVariablesOrProperties>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0003DoNotUseObjectIDsInVariablesOrProperties.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0003DoNotUseObjectIDsInVariablesOrProperties.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0004.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0004.cs
@@ -19,7 +19,7 @@ public class Rule0004
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0004LookupPageIdAndDrillDownPageId>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0004LookupPageIdAndDrillDownPageId.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0004LookupPageIdAndDrillDownPageId.Id);
     }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0004
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0004LookupPageIdAndDrillDownPageId>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0004LookupPageIdAndDrillDownPageId.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0004LookupPageIdAndDrillDownPageId.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0005.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0005.cs
@@ -21,7 +21,7 @@ public class Rule0005
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0005VariableCasingShouldNotDifferFromDeclaration>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0005VariableCasingShouldNotDifferFromDeclaration.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0005VariableCasingShouldNotDifferFromDeclaration.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0005
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0005VariableCasingShouldNotDifferFromDeclaration>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0005VariableCasingShouldNotDifferFromDeclaration.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0005VariableCasingShouldNotDifferFromDeclaration.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0006.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0006.cs
@@ -19,7 +19,7 @@ public class Rule0006
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0006FieldNotAutoIncrementInTemporaryTable>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0006FieldNotAutoIncrementInTemporaryTable.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0006FieldNotAutoIncrementInTemporaryTable.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0006
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0006FieldNotAutoIncrementInTemporaryTable>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0006FieldNotAutoIncrementInTemporaryTable.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0006FieldNotAutoIncrementInTemporaryTable.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0007.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0007.cs
@@ -20,7 +20,7 @@ public class Rule0007
     //         .ConfigureAwait(false);
 
     //     var fixture = RoslynFixtureFactory.Create<Rule0007DataPerCompanyShouldAlwaysBeSet>();
-    //     fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0007DataPerCompanyShouldAlwaysBeSet.Id);
+    //     fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0007DataPerCompanyShouldAlwaysBeSet.Id);
     // }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0007
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0007DataPerCompanyShouldAlwaysBeSet>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0007DataPerCompanyShouldAlwaysBeSet.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0007DataPerCompanyShouldAlwaysBeSet.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0008.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0008.cs
@@ -19,7 +19,7 @@ public class Rule0008
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0008NoFilterOperatorsInSetRange>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0008NoFilterOperatorsInSetRange.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0008NoFilterOperatorsInSetRange.Id);
     }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0008
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0008NoFilterOperatorsInSetRange>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0008NoFilterOperatorsInSetRange.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0008NoFilterOperatorsInSetRange.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0011.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0011.cs
@@ -20,7 +20,7 @@ public class Rule0011
     //         .ConfigureAwait(false);
 
     //     var fixture = RoslynFixtureFactory.Create<Rule0011DataPerCompanyShouldAlwaysBeSet>();
-    //     fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0011AccessPropertyShouldAlwaysBeSet.Id);
+    //     fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0011AccessPropertyShouldAlwaysBeSet.Id);
     // }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0011
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0011DataPerCompanyShouldAlwaysBeSet>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0011AccessPropertyShouldAlwaysBeSet.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0011AccessPropertyShouldAlwaysBeSet.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0012.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0012.cs
@@ -19,7 +19,7 @@ public class Rule0012
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0012DoNotUseObjectIdInSystemFunctions>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0012DoNotUseObjectIdInSystemFunctions.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0012DoNotUseObjectIdInSystemFunctions.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0012
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0012DoNotUseObjectIdInSystemFunctions>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0012DoNotUseObjectIdInSystemFunctions.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0012DoNotUseObjectIdInSystemFunctions.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0013.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0013.cs
@@ -19,7 +19,7 @@ public class Rule0013
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0013
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0014.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0014.cs
@@ -21,7 +21,7 @@ public class Rule0014
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0014PermissionSetCaptionLength>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0014PermissionSetCaptionLength.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0014PermissionSetCaptionLength.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0014
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0014PermissionSetCaptionLength>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0014PermissionSetCaptionLength.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0014PermissionSetCaptionLength.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0015.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0015.cs
@@ -20,7 +20,7 @@ public class Rule0015
     //         .ConfigureAwait(false);
 
     //     var fixture = RoslynFixtureFactory.Create<Rule0015PermissionSetCoverage>();
-    //     fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0015PermissionSetCoverage.Id);
+    //     fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0015PermissionSetCoverage.Id);
     // }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0015
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0015PermissionSetCoverage>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0015PermissionSetCoverage.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0015PermissionSetCoverage.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0016.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0016.cs
@@ -27,7 +27,7 @@ public class Rule0016
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0016CheckForMissingCaptions>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0016CheckForMissingCaptions.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0016CheckForMissingCaptions.Id);
     }
 
     [Test]
@@ -46,6 +46,6 @@ public class Rule0016
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0016CheckForMissingCaptions>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0016CheckForMissingCaptions.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0016CheckForMissingCaptions.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0017.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0017.cs
@@ -20,7 +20,7 @@ public class Rule0017
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0017WriteToFlowField>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0017WriteToFlowField.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0017WriteToFlowField.Id);
     }
 
     [Test]
@@ -35,6 +35,6 @@ public class Rule0017
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0017WriteToFlowField>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0017WriteToFlowField.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0017WriteToFlowField.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0018.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0018.cs
@@ -19,7 +19,7 @@ public class Rule0018
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0018NoEventsInInternalCodeunits>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0018NoEventsInInternalCodeunitsAnalyzerDescriptor.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0018NoEventsInInternalCodeunitsAnalyzerDescriptor.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0018
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0018NoEventsInInternalCodeunits>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0018NoEventsInInternalCodeunitsAnalyzerDescriptor.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0018NoEventsInInternalCodeunitsAnalyzerDescriptor.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0019.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0019.cs
@@ -19,7 +19,7 @@ public class Rule0019
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0019DataClassificationFieldEqualsTable>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0019DataClassificationFieldEqualsTable.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0019DataClassificationFieldEqualsTable.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0019
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0019DataClassificationFieldEqualsTable>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0019DataClassificationFieldEqualsTable.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0019DataClassificationFieldEqualsTable.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0020.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0020.cs
@@ -19,7 +19,7 @@ public class Rule0020
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0020ApplicationAreaEqualsToPage>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0020ApplicationAreaEqualsToPage.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0020ApplicationAreaEqualsToPage.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0020
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0020ApplicationAreaEqualsToPage>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0020ApplicationAreaEqualsToPage.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0020ApplicationAreaEqualsToPage.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0021.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0021.cs
@@ -19,7 +19,7 @@ public class Rule0021
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<BuiltInMethodImplementThroughCodeunit>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0021ConfirmImplementConfirmManagement.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0021ConfirmImplementConfirmManagement.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0021
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<BuiltInMethodImplementThroughCodeunit>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0021ConfirmImplementConfirmManagement.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0021ConfirmImplementConfirmManagement.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0022.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0022.cs
@@ -19,7 +19,7 @@ public class Rule0022
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<BuiltInMethodImplementThroughCodeunit>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0022GlobalLanguageImplementTranslationHelper.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0022GlobalLanguageImplementTranslationHelper.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0022
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<BuiltInMethodImplementThroughCodeunit>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0022GlobalLanguageImplementTranslationHelper.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0022GlobalLanguageImplementTranslationHelper.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0023.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0023.cs
@@ -20,7 +20,7 @@ public class Rule0023
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0023AlwaysSpecifyFieldgroups>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0023AlwaysSpecifyFieldgroups.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0023AlwaysSpecifyFieldgroups.Id);
     }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0023
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0023AlwaysSpecifyFieldgroups>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0023AlwaysSpecifyFieldgroups.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0023AlwaysSpecifyFieldgroups.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0024.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0024.cs
@@ -19,7 +19,7 @@ public class Rule0024
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0024SemicolonAfterMethodOrTriggerDeclaration>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0024SemicolonAfterMethodOrTriggerDeclaration.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0024SemicolonAfterMethodOrTriggerDeclaration.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0024
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0024SemicolonAfterMethodOrTriggerDeclaration>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0024SemicolonAfterMethodOrTriggerDeclaration.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0024SemicolonAfterMethodOrTriggerDeclaration.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0025.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0025.cs
@@ -19,7 +19,7 @@ public class Rule0025
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0025InternalProcedureModifier>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0025InternalProcedureModifier.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0025InternalProcedureModifier.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0025
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0025InternalProcedureModifier>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0025InternalProcedureModifier.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0025InternalProcedureModifier.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0026.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0026.cs
@@ -23,7 +23,7 @@ public class Rule0026
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0026ToolTipPunctuation>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0026ToolTipMustEndWithDot.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0026ToolTipMustEndWithDot.Id);
     }
 
     [Test]
@@ -38,6 +38,6 @@ public class Rule0026
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0026ToolTipPunctuation>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0026ToolTipMustEndWithDot.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0026ToolTipMustEndWithDot.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0027.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0027.cs
@@ -20,7 +20,7 @@ public class Rule0027
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0027RunPageImplementPageManagement>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0027RunPageImplementPageManagement.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0027RunPageImplementPageManagement.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0027
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0027RunPageImplementPageManagement>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0027RunPageImplementPageManagement.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0027RunPageImplementPageManagement.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0028.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0028.cs
@@ -19,7 +19,7 @@ public class Rule0028
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0028CodeNavigabilityOnEventSubscribers>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0028IdentifiersInEventSubscribers.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0028IdentifiersInEventSubscribers.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0028
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0028CodeNavigabilityOnEventSubscribers>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0028IdentifiersInEventSubscribers.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0028IdentifiersInEventSubscribers.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0030.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0030.cs
@@ -20,7 +20,7 @@ public class Rule0030
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0030AccessInternalForInstallAndUpgradeCodeunits>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0030AccessInternalForInstallAndUpgradeCodeunits.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0030AccessInternalForInstallAndUpgradeCodeunits.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0030
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0030AccessInternalForInstallAndUpgradeCodeunits>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0030AccessInternalForInstallAndUpgradeCodeunits.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0030AccessInternalForInstallAndUpgradeCodeunits.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0031.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0031.cs
@@ -19,7 +19,7 @@ public class Rule0031
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0031RecordInstanceIsolationLevel>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0031RecordInstanceIsolationLevel.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0031RecordInstanceIsolationLevel.Id);
     }
 
     // [Test]
@@ -29,6 +29,6 @@ public class Rule0031
     //         .ConfigureAwait(false);
     //
     //     var fixture = RoslynFixtureFactory.Create<Rule0031RecordInstanceIsolationLevel>();
-    //     fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0031RecordInstanceIsolationLevel.Id);
+    //     fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0031RecordInstanceIsolationLevel.Id);
     // }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0032.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0032.cs
@@ -20,7 +20,7 @@ public class Rule0032
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0032ClearCodeunitSingleInstance>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0032ClearCodeunitSingleInstance.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0032ClearCodeunitSingleInstance.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0032
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0032ClearCodeunitSingleInstance>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0032ClearCodeunitSingleInstance.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0032ClearCodeunitSingleInstance.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0043.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0043.cs
@@ -23,7 +23,7 @@ public class Rule0043
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0043SecretText>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0043SecretText.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0043SecretText.Id);
     }
 
     [Test]
@@ -37,7 +37,7 @@ public class Rule0043
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0043SecretText>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0043SecretText.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0043SecretText.Id);
     }
 }
 #endif

--- a/BusinessCentral.LinterCop.Test/Rule0044.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0044.cs
@@ -22,7 +22,7 @@ public class Rule0044
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0044AnalyzeTransferFields>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0044AnalyzeTransferFields.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0044AnalyzeTransferFields.Id);
     }
 
 #if !LessThenSpring2024
@@ -36,6 +36,6 @@ public class Rule0044
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0044AnalyzeTransferFields>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0044AnalyzeTransferFields.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0044AnalyzeTransferFields.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0048.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0048.cs
@@ -23,7 +23,7 @@ public class Rule0048
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0048ErrorWithTextConstant>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0048ErrorWithTextConstant.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0048ErrorWithTextConstant.Id);
     }
 
     [Test]
@@ -38,6 +38,6 @@ public class Rule0048
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0048ErrorWithTextConstant>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0048ErrorWithTextConstant.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0048ErrorWithTextConstant.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0051.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0051.cs
@@ -25,7 +25,7 @@ public class Rule0051
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0051PossibleOverflowAssigning>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0051PossibleOverflowAssigning.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0051PossibleOverflowAssigning.Id);
     }
 
     [Test]
@@ -43,7 +43,7 @@ public class Rule0051
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0051PossibleOverflowAssigning>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0051PossibleOverflowAssigning.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0051PossibleOverflowAssigning.Id);
     }
 }
 #endif

--- a/BusinessCentral.LinterCop.Test/Rule0059.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0059.cs
@@ -20,7 +20,7 @@ public class Rule0059
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0059SingleQuoteEscaping>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0059SingleQuoteEscapingIssueDetected.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0059SingleQuoteEscapingIssueDetected.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0059
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0059SingleQuoteEscaping>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0059SingleQuoteEscapingIssueDetected.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0059SingleQuoteEscapingIssueDetected.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0065.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0065.cs
@@ -19,7 +19,7 @@ public class Rule0065
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0065CheckEventSubscriberVarKeyword>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0065EventSubscriberVarCheck.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0065EventSubscriberVarCheck.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0065
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0065CheckEventSubscriberVarKeyword>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0065EventSubscriberVarCheck.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0065EventSubscriberVarCheck.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0067.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0067.cs
@@ -21,7 +21,7 @@ public class Rule0067
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0067DisableNotBlankOnSingleFieldPrimaryKey.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0067DisableNotBlankOnSingleFieldPrimaryKey.Id);
     }
 
     [Test]
@@ -35,6 +35,6 @@ public class Rule0067
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0013CheckForNotBlankOnSingleFieldPrimaryKeys>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0067DisableNotBlankOnSingleFieldPrimaryKey.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0067DisableNotBlankOnSingleFieldPrimaryKey.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -22,7 +22,7 @@ public class Rule0068
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0068CheckObjectPermission>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0068CheckObjectPermission.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0068CheckObjectPermission.Id);
     }
 
     [Test]
@@ -47,6 +47,6 @@ public class Rule0068
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0068CheckObjectPermission>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0068CheckObjectPermission.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0068CheckObjectPermission.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0069.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0069.cs
@@ -19,7 +19,7 @@ public class Rule0069
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0069EmptyStatements>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0069EmptyStatements.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0069EmptyStatements.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0069
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0069EmptyStatements>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0069EmptyStatements.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0069EmptyStatements.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0070.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0070.cs
@@ -20,7 +20,7 @@ public class Rule0070
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0070ListObjectsAreOneBased>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0070ListObjectsAreOneBased.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0070ListObjectsAreOneBased.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0070
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0070ListObjectsAreOneBased>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0070ListObjectsAreOneBased.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0070ListObjectsAreOneBased.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0071.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0071.cs
@@ -23,7 +23,7 @@ public class Rule0071
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0071DoNotSetIsHandledToFalse>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0071DoNotSetIsHandledToFalse.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0071DoNotSetIsHandledToFalse.Id);
     }
 
     [Test]
@@ -38,6 +38,6 @@ public class Rule0071
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0071DoNotSetIsHandledToFalse>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0071DoNotSetIsHandledToFalse.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0071DoNotSetIsHandledToFalse.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0072.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0072.cs
@@ -20,7 +20,7 @@ public class Rule0072
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0072CheckProcedureDocumentationComment>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0072CheckProcedureDocumentationComment.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0072CheckProcedureDocumentationComment.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0072
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0072CheckProcedureDocumentationComment>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0072CheckProcedureDocumentationComment.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0072CheckProcedureDocumentationComment.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0073.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0073.cs
@@ -20,7 +20,7 @@ public class Rule0073
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0073EventPublisherIsHandledByVar>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0073EventPublisherIsHandledByVar.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0073EventPublisherIsHandledByVar.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0073
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0073EventPublisherIsHandledByVar>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0073EventPublisherIsHandledByVar.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0073EventPublisherIsHandledByVar.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0074.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0074.cs
@@ -20,7 +20,7 @@ public class Rule0074
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0074FlowFilterAssignment>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0074FlowFilterAssignment.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0074FlowFilterAssignment.Id);
     }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0074
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0074FlowFilterAssignment>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0074FlowFilterAssignment.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0074FlowFilterAssignment.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0075.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0075.cs
@@ -32,7 +32,7 @@ public class Rule0075
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0075RecordGetProcedureArguments>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0075RecordGetProcedureArguments.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0075RecordGetProcedureArguments.Id);
     }
 
     [Test]
@@ -63,7 +63,7 @@ public class Rule0075
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0075RecordGetProcedureArguments>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0075RecordGetProcedureArguments.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0075RecordGetProcedureArguments.Id);
     }
 }
 #endif

--- a/BusinessCentral.LinterCop.Test/Rule0076.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0076.cs
@@ -25,7 +25,7 @@ public class Rule0076
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0076TableRelationTooLong>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0076TableRelationTooLong.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0076TableRelationTooLong.Id);
     }
 
     [Test]
@@ -41,6 +41,6 @@ public class Rule0076
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0076TableRelationTooLong>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0076TableRelationTooLong.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0076TableRelationTooLong.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0077.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0077.cs
@@ -19,7 +19,7 @@ public class Rule0077
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0077MissingParenthesis>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0077MissingParenthesis.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0077MissingParenthesis.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0077
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0077MissingParenthesis>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0077MissingParenthesis.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0077MissingParenthesis.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0078.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0078.cs
@@ -19,7 +19,7 @@ public class Rule0078
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0078TemporaryRecordsShouldNotTriggerTableTriggers>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0078
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0078TemporaryRecordsShouldNotTriggerTableTriggers>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0078TemporaryRecordsShouldNotTriggerTableTriggers.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0079.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0079.cs
@@ -19,7 +19,7 @@ public class Rule0079
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0079NonPublicEventPublisher>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0079NonPublicEventPublisher.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0079NonPublicEventPublisher.Id);
     }
 
     [Test]
@@ -31,6 +31,6 @@ public class Rule0079
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0079NonPublicEventPublisher>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0079NonPublicEventPublisher.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0079NonPublicEventPublisher.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0080.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0080.cs
@@ -19,7 +19,7 @@ public class Rule0080
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0080AnalyzeJsonTokenJPath>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0080AnalyzeJsonTokenJPath.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0080AnalyzeJsonTokenJPath.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0080
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0080AnalyzeJsonTokenJPath>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0080AnalyzeJsonTokenJPath.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0080AnalyzeJsonTokenJPath.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0081.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0081.cs
@@ -26,7 +26,7 @@ public class Rule0081
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0081AnalyzeCountMethod>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0081UseIsEmptyMethod.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0081UseIsEmptyMethod.Id);
     }
 
     [Test]
@@ -38,6 +38,6 @@ public class Rule0081
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0081AnalyzeCountMethod>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0081UseIsEmptyMethod.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0081UseIsEmptyMethod.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0082.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0082.cs
@@ -25,7 +25,7 @@ public class Rule0082
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0081AnalyzeCountMethod>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0082UseFindWithNext.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0082UseFindWithNext.Id);
     }
 
     [Test]
@@ -37,6 +37,6 @@ public class Rule0082
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0081AnalyzeCountMethod>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0082UseFindWithNext.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0082UseFindWithNext.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0083.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0083.cs
@@ -27,7 +27,7 @@ public class Rule0083
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0083BuiltInDateTimeMethod>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0083BuiltInDateTimeMethod.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0083BuiltInDateTimeMethod.Id);
     }
 
     // [Test]
@@ -37,7 +37,7 @@ public class Rule0083
     //         .ConfigureAwait(false);
 
     //     var fixture = RoslynFixtureFactory.Create<Rule0083BuiltInDateTimeMethod>();
-    //     fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0083BuiltInDateTimeMethod.Id);
+    //     fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0083BuiltInDateTimeMethod.Id);
     // }
 }
 #endif

--- a/BusinessCentral.LinterCop.Test/Rule0084.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0084.cs
@@ -20,7 +20,7 @@ public class Rule0084
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0084UseReturnValueForErrorHandling>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0084UseReturnValueForErrorHandling.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0084UseReturnValueForErrorHandling.Id);
     }
 
     [Test]
@@ -32,6 +32,6 @@ public class Rule0084
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0084UseReturnValueForErrorHandling>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0084UseReturnValueForErrorHandling.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0084UseReturnValueForErrorHandling.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0085.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0085.cs
@@ -21,7 +21,7 @@ public class Rule0085
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0085LFSeparator>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0085LFSeparator.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0085LFSeparator.Id);
     }
 
     [Test]
@@ -33,6 +33,6 @@ public class Rule0085
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0085LFSeparator>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0085LFSeparator.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0085LFSeparator.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0086.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0086.cs
@@ -21,7 +21,7 @@ public class Rule0086
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0086PageStyleDataType>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0086PageStyleDataType.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0086PageStyleDataType.Id);
     }
 
     [Test]
@@ -34,7 +34,7 @@ public class Rule0086
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0086PageStyleDataType>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0086PageStyleDataType.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0086PageStyleDataType.Id);
     }
 }
 #endif

--- a/BusinessCentral.LinterCop.Test/Rule0087.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0087.cs
@@ -19,7 +19,7 @@ public class Rule0087
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0087UseIsNullGuid>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0087UseIsNullGuid.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0087UseIsNullGuid.Id);
     }
 
     [Test]
@@ -30,6 +30,6 @@ public class Rule0087
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0087UseIsNullGuid>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0087UseIsNullGuid.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0087UseIsNullGuid.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0088.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0088.cs
@@ -29,7 +29,7 @@ namespace BusinessCentral.LinterCop.Test
                 .ConfigureAwait(false);
 
             var fixture = RoslynFixtureFactory.Create<Rule0088AvoidOptionTypes>();
-            fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0088AvoidOptionTypes.Id);
+            fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0088AvoidOptionTypes.Id);
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace BusinessCentral.LinterCop.Test
                 .ConfigureAwait(false);
 
             var fixture = RoslynFixtureFactory.Create<Rule0088AvoidOptionTypes>();
-            fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0088AvoidOptionTypes.Id);
+            fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0088AvoidOptionTypes.Id);
         }
     }
 }

--- a/BusinessCentral.LinterCop.Test/Rule0089.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0089.cs
@@ -27,7 +27,7 @@ public class Rule0089
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0089CognitiveComplexity>();
-        fixture.HasDiagnostic(code, DiagnosticDescriptors.Rule0090CognitiveComplexity.Id);
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0090CognitiveComplexity.Id);
     }
 
     [Test]
@@ -46,6 +46,6 @@ public class Rule0089
             .ConfigureAwait(false);
 
         var fixture = RoslynFixtureFactory.Create<Rule0089CognitiveComplexity>();
-        fixture.NoDiagnosticAtMarker(code, DiagnosticDescriptors.Rule0090CognitiveComplexity.Id);
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0090CognitiveComplexity.Id);
     }
 }

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0005/HasDiagnostic/OptionAccessExpression.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0005/HasDiagnostic/OptionAccessExpression.al
@@ -8,7 +8,7 @@ codeunit 50100 OptionAccessExpression
         i := [|codeunit|]::MyCodeunit;
 
         i := [|DATABASE|]::MyTable;
-        i := [|Database|]::MyTable;
+        i := [|database|]::MyTable;
 
         i := [|ENUM|]::MyEnum::MyValue;
         i := [|enum|]::MyEnum::MyValue;


### PR DESCRIPTION
Fixes #952.

As described in the issue, currently only the first marker is evaluated (see file `CodeMarkup.cs` method `GetLocator`).
This PR adds support for all markers, while keeping the existing option to only test for one (the first) marker.
Two new methods for all markers were added, and i applied them to all the test classes: `HasDiagnosticAtAllMarkers` and `NoDiagnosticAtAllMarkers`.

It seems that most test cases were still correct, the only error this change surfaced was a testcase for LC0005:
```al
i := [|Database|]::MyTable; // this was expecting a diagnostic, but "Database" is actually correct casing
i := [|database|]::MyTable; // changed to the likely intended testcase of "database" being incorrect casing
```

If this change is correct and should be merged, then it may be good to check any PRs that are outstanding or were merged in the meantime to also use the "all markers" methods.

Any feedback is very much welcome :)