### PR TITLE
LC0068: Break permission analysis after requested object permission was found

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0068.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0068.cs
@@ -46,7 +46,8 @@ public class Rule0068
     [TestCase("XMLPortWithTableElementProps")]
     [TestCase("PermissionsAsObjectId")]
     [TestCase("PermissionPropertyWithPragma")]
-    [TestCase("PermissionPropertyWithComment")] 
+    [TestCase("PermissionPropertyWithComment")]
+    [TestCase("MultiplePermissionsDifferentType")] 
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/MultiplePermissionsDifferentType.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0068/NoDiagnostic/MultiplePermissionsDifferentType.al
@@ -1,0 +1,31 @@
+codeunit 50000 Test
+{
+    Permissions =
+        tabledata MyTableOne = r,
+        tabledata MyTableTwo = i;
+
+    procedure Test()
+    var
+        MyTableOne: Record MyTableOne;
+        MyTableTwo: Record MyTableTwo;
+    begin
+        [|MyTableOne.FindFirst();|]
+        [|MyTableTwo.Insert();|]
+    end;
+}
+
+table 50000 MyTableOne
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+table 50001 MyTableTwo
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}

--- a/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0068CheckObjectPermission.cs
@@ -233,6 +233,7 @@ public class Rule0068CheckObjectPermission : DiagnosticAnalyzer
                 var permissionsText = permission.Permissions.ValueText;
                 if (permissionsText is null || !permissionsText.ToLowerInvariant().Contains(requestedPermission))
                     ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0068CheckObjectPermission, location, requestedPermission, variableType.Name));
+                break; // analysed the permissions for the requested object, break the foreach loop
             }
         }
         if (!permissionContainRequestedObject)


### PR DESCRIPTION
fixes #962, #923 (again :/)

Made the mistake of not adding a break after `permissionContainRequestedObject` is set, which caused additional unnecessary iterations where the permission of unrelated objects was checked leading to false positives.