### PR TITLE
Added test for codefixer of rule LC0001

### DIFF
--- a/BusinessCentral.LinterCop.Test/CodeFixerTests/Fix0001/Fix0001.cs
+++ b/BusinessCentral.LinterCop.Test/CodeFixerTests/Fix0001/Fix0001.cs
@@ -1,0 +1,24 @@
+﻿using BusinessCentral.LinterCop.CodeFixes;
+using BusinessCentral.LinterCop.Test.Helpers;
+
+namespace BusinessCentral.LinterCop.Test.CodeFixerTests.Fix0001;
+
+internal class Fix0001
+{
+    [Test]
+    [TestCase("SingleFlowFieldIsEditable")]
+    public async Task HasFix(string testCase)
+    {
+        var currentCode = await CodeFixerTestHelpers.GetCodeFixerTestCode(nameof(Fix0001), nameof(HasFix), testCase, "current.al");
+        var expectedCode = await CodeFixerTestHelpers.GetCodeFixerTestCode(nameof(Fix0001), nameof(HasFix), testCase, "expected.al");
+
+        var fixture = RoslynFixtureFactory.Create<Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider>(
+            new CodeFixTestFixtureConfig
+            {
+                AdditionalAnalyzers = [new Rule0001FlowFieldsShouldNotBeEditable()]
+            });
+
+        fixture.TestCodeFix(currentCode, expectedCode, DiagnosticDescriptors.Rule0001FlowFieldsShouldNotBeEditable);
+    }
+
+}

--- a/BusinessCentral.LinterCop.Test/CodeFixerTests/Fix0001/HasFix/SingleFlowFieldIsEditable/current.al
+++ b/BusinessCentral.LinterCop.Test/CodeFixerTests/Fix0001/HasFix/SingleFlowFieldIsEditable/current.al
@@ -1,0 +1,27 @@
+table 50100 "My Table Test"
+{
+    Caption = 'My Table Test';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Test; Code[10])
+        {
+            Caption = 'Test';
+        }
+        field(2; [|Test2|]; Decimal)
+        {
+            Caption = 'Test2';
+            FieldClass = FlowField;
+            CalcFormula = sum("Sales Line".Amount);
+        }
+    }
+    
+    keys
+    {
+        key(PK; Test)
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/CodeFixerTests/Fix0001/HasFix/SingleFlowFieldIsEditable/expected.al
+++ b/BusinessCentral.LinterCop.Test/CodeFixerTests/Fix0001/HasFix/SingleFlowFieldIsEditable/expected.al
@@ -1,0 +1,28 @@
+table 50100 "My Table Test"
+{
+    Caption = 'My Table Test';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Test; Code[10])
+        {
+            Caption = 'Test';
+        }
+        field(2; Test2; Decimal)
+        {
+            Caption = 'Test2';
+            FieldClass = FlowField;
+            CalcFormula = sum("Sales Line".Amount);
+            Editable = false;
+        }
+    }
+    
+    keys
+    {
+        key(PK; Test)
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/Helpers/CodeFixerTestHelpers.cs
+++ b/BusinessCentral.LinterCop.Test/Helpers/CodeFixerTestHelpers.cs
@@ -1,0 +1,11 @@
+﻿namespace BusinessCentral.LinterCop.Test.Helpers;
+
+internal static class CodeFixerTestHelpers
+{
+    private static readonly string BasePath = Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName;
+ 
+    public static async Task<string> GetCodeFixerTestCode(string className, params string[] folders)
+    {
+        return await File.ReadAllTextAsync(Path.Combine([BasePath, "CodeFixerTests", className, .. folders])).ConfigureAwait(false);
+    }
+}

--- a/BusinessCentral.LinterCop/CodeFixes/Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider.cs
+++ b/BusinessCentral.LinterCop/CodeFixes/Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider.cs
@@ -4,10 +4,11 @@ using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.CodeFixes;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces;
+using Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef;
 
 namespace BusinessCentral.LinterCop.CodeFixes;
 
-[Microsoft.Dynamics.Nav.CodeAnalysis.CodeActions.Mef.CodeFixProvider("Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider")]
+[CodeFixProvider(nameof(Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider))]
 public sealed class Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider : CodeFixProvider
 {
     private class Fix0001FlowFieldsShouldNotBeEditableCodeAction : CodeAction.DocumentChangeAction
@@ -16,7 +17,9 @@ public sealed class Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider : CodeFi
         public override bool SupportsFixAll { get; }
         public override string? FixAllSingleInstanceTitle => string.Empty;
         public override string? FixAllTitle => Title;
-        public Fix0001FlowFieldsShouldNotBeEditableCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey, bool generateFixAll)
+
+        public Fix0001FlowFieldsShouldNotBeEditableCodeAction(string title,
+            Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey, bool generateFixAll)
             : base(title, createChangedDocument, equivalenceKey)
         {
             SupportsFixAll = generateFixAll;
@@ -45,8 +48,15 @@ public sealed class Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider : CodeFi
         ctx.RegisterCodeFix(CreateCodeAction(node, document, true), ctx.Diagnostics[0]);
     }
 
-    private static Fix0001FlowFieldsShouldNotBeEditableCodeAction CreateCodeAction(SyntaxNode node, Document document, bool generateFixAll) =>
-        new(LinterCopAnalyzers.Fix0001FlowFieldsShouldNotBeEditableCodeAction, ct => SetEditablePropertyForField(document, node, ct), "Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider", generateFixAll);
+    private static Fix0001FlowFieldsShouldNotBeEditableCodeAction CreateCodeAction(SyntaxNode node, Document document,
+        bool generateFixAll)
+    {
+        return new Fix0001FlowFieldsShouldNotBeEditableCodeAction(
+            LinterCopAnalyzers.Fix0001FlowFieldsShouldNotBeEditableCodeAction,
+            ct => SetEditablePropertyForField(document, node, ct),
+            nameof(Fix0001FlowFieldsShouldNotBeEditableCodeFixProvider),
+            generateFixAll);
+    }
 
     private static async Task<Document> SetEditablePropertyForField(Document document, SyntaxNode node, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
I was curious how to test the newly introduced code actions and found out that the RoslynTestKit already supports them.
So I added a test for the first rule as an example.

Instead of 1,2,3,4 for the test cases, I tried to give them meaningful names.

The test framework could be improved, as you currently always have to include the ``DiagnosticAnalyzer`` as AdditionalAnalyzer parameter.