### PR TITLE
LC0071 Add SelfGuardedOrAssignment Check

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0071.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0071.cs
@@ -17,6 +17,7 @@ public class Rule0071
     [TestCase("Handled")]
     [TestCase("PrecedingExitOnAssignment")]
     [TestCase("PrecedingExitOnInvocation")]
+    [TestCase("SelfGuardedOrAssignment")]
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
@@ -32,6 +33,7 @@ public class Rule0071
     [TestCase("NoEventSubscriberParameterReference")]
     [TestCase("PrecedingExitOnAssignment")]
     [TestCase("PrecedingExitOnInvocation")]
+    [TestCase("SelfGuardedOrAssignment")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0071/HasDiagnostic/SelfGuardedOrAssignment.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0071/HasDiagnostic/SelfGuardedOrAssignment.al
@@ -1,0 +1,17 @@
+codeunit 50000 MyCodeunit
+{
+    [IntegrationEvent(false, false)]
+    local procedure OnMyEvent(var IsHandled: Boolean)
+    begin
+    end;
+}
+
+codeunit 50001 MySubscriber
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::MyCodeunit, OnMyEvent, '', false, false)]
+    local procedure OnMyEventSubscriber(var IsHandled: Boolean)
+    begin
+        [|IsHandled := IsHandled and (Random(2) = 1);|]
+        [|IsHandled := (IsHandled or (Random(2) = 1)) and (Random(2) = 1);|]
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0071/NoDiagnostic/SelfGuardedOrAssignment.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0071/NoDiagnostic/SelfGuardedOrAssignment.al
@@ -1,0 +1,17 @@
+codeunit 50000 MyCodeunit
+{
+    [IntegrationEvent(false, false)]
+    local procedure OnMyEvent(var IsHandled: Boolean)
+    begin
+    end;
+}
+
+codeunit 50001 MySubscriber
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::MyCodeunit, OnMyEvent, '', false, false)]
+    local procedure OnMyEventSubscriber(var IsHandled: Boolean)
+    begin
+        [|IsHandled := IsHandled or (Random(2) = 1);|]
+        [|IsHandled := (Random(2) = 1) or IsHandled;|]
+    end;
+}


### PR DESCRIPTION
fixes #997 

Adds a check for the pattern `IsHandled := IsHandled or (Random(2) = 1);` where IsHandled is guaranteed to never be set to false if it was true.

Note: Currently the additional check is only for a top-level `IsHandled or`, any expressions where the `IsHandled` is nested in the logical expression are not further analysed (as that could become quite complex).

Note 2: For chained `or` expressions (`IsHandled := IsHandled or [...] or [...] or [...]` and so on) the AL compiler seems to currently interpret the expression as a nested expression starting from the left side. So given the two examples:
- `IsHandled := IsHandled or Exp1 or Exp2;`
- `IsHandled := Exp1 or Exp2 or IsHandled;`
The first one will raise the diagnostic, while the second will not, even if they evaluate the same (since afaik AL does no lazy evaluation).
This could probably be improved, but for now i treated it the same as nested expressions (too complex).
The diagnostic for the example 1 can also be fixed by adding parenthesis: `IsHandled := IsHandled or (Exp1 or Exp2);`