### PR TITLE
Don't suggest to replace d2dwy(date, 3) with date.Year()

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0083BuiltInDateTimeMethod.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0083BuiltInDateTimeMethod.cs
@@ -72,7 +72,7 @@ public class Rule0083BuiltInDateTimeMethod : DiagnosticAnalyzer
         {
             1 => "DayOfWeek()",
             2 => "WeekNo()",
-            3 => "Year()",
+            3 => null,
             _ => null
         };
     }

--- a/BusinessCentral.LinterCop/Design/Rule0083BuiltInDateTimeMethod.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0083BuiltInDateTimeMethod.cs
@@ -72,7 +72,7 @@ public class Rule0083BuiltInDateTimeMethod : DiagnosticAnalyzer
         {
             1 => "DayOfWeek()",
             2 => "WeekNo()",
-            3 => null,
+            3 => null, // Year() isn't returnig the same value. When the input date to the Date2DWY method is in a week that spans two years, the Date2DWY method computes the output year as the year that has the most days.
             _ => null
         };
     }


### PR DESCRIPTION
When the input date to the Date2DWY method is in a week that spans two years, the Date2DWY method computes the output year as the year that has the most days. For example, the input date is 010114. This date is in a week that starts on Monday, December 29, 2013, and ends Sunday, January 4, 2014. The week has three days in 2013 and four days in 2014. So the output year is 2014.
See: https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/system/system-date2dwy-method#remarks

Fixes #1034 