### PR TITLE
Matching target extension objects by extension id

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0091LabelsShouldBeTranslated.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0091LabelsShouldBeTranslated.cs
@@ -314,22 +314,22 @@ public class Rule0091LabelsShouldBeTranslated : DiagnosticAnalyzer
         }
 
         if (symbol is ITableExtensionTypeSymbol tableExtension &&
-            tableExtension.Target?.ContainingNamespace != null &&
-            labelSymbol.ContainingNamespace != null &&
-            tableExtension.Target.ContainingNamespace.Equals(labelSymbol.ContainingNamespace))
+            tableExtension.Target?.ContainingModule != null &&
+            labelSymbol.ContainingModule != null &&
+            tableExtension.Target.ContainingModule.AppId.Equals(labelSymbol.ContainingModule.AppId))
             return (IRootTypeSymbol)tableExtension.Target;
 
         if (symbol is IPageExtensionTypeSymbol pageExtension &&
-            pageExtension.Target?.ContainingNamespace != null &&
-            labelSymbol.ContainingNamespace != null &&
-            pageExtension.Target.ContainingNamespace.Equals(labelSymbol.ContainingNamespace))
+            pageExtension.Target?.ContainingModule != null &&
+            labelSymbol.ContainingModule != null &&
+            pageExtension.Target.ContainingModule.AppId.Equals(labelSymbol.ContainingModule.AppId))
             return (IRootTypeSymbol)pageExtension.Target;
 
 #if !LessThenFall2024
         if (symbol is IReportExtensionTypeSymbol reportExtension &&
-            reportExtension.Target?.ContainingNamespace != null &&
-            labelSymbol.ContainingNamespace != null &&
-            reportExtension.Target.ContainingNamespace.Equals(labelSymbol.ContainingNamespace))
+            reportExtension.Target?.ContainingModule != null &&
+            labelSymbol.ContainingModule != null &&
+            reportExtension.Target.ContainingModule.AppId.Equals(labelSymbol.ContainingModule.AppId))
             return (IRootTypeSymbol)reportExtension.Target;
 #endif
 


### PR DESCRIPTION
This change should deal with most of the extension object issues. 
There is still one bug in there I can't get a hold of:
For example, creating 2 page extensions in the same app on the same target object will result in one of the page extensions to throw false positives

Reason behind this is the following:
![image](https://github.com/user-attachments/assets/1bad1ff0-3e5f-4454-aa93-25acfb499f35)
![image](https://github.com/user-attachments/assets/34152fea-fcc7-496e-bb61-d13d074fcb81)

All translation IDs are generated by hashing the value `BlanketSalesOrderExt`, this way every translation of the second page extension can't be found.