### PR TITLE
Add Global Setting support

### DIFF
--- a/BusinessCentral.LinterCop/Helpers/LinterSettings.cs
+++ b/BusinessCentral.LinterCop/Helpers/LinterSettings.cs
@@ -20,7 +20,15 @@ namespace BusinessCentral.LinterCop.Helpers
             {
                 try
                 {
-                    StreamReader r = File.OpenText(Path.Combine(WorkingDir, "LinterCop.json"));
+                    StreamReader r = null;
+                    if (File.Exists(Path.Combine(WorkingDir, "LinterCop.json")))
+                    {
+                        r = File.OpenText(Path.Combine(WorkingDir, "LinterCop.json"));
+                    }
+                    else
+                    {
+                        r = File.OpenText(Path.Combine(Path.GetDirectoryName(typeof(LinterSettings).Assembly.Location)!, "LinterCop.json")); 
+                    }
                     string json = r.ReadToEnd();
                     r.Close();
                     instance = new LinterSettings();


### PR DESCRIPTION
This feature will add support for a global LinterCop.json setting file. 
It will check if the file exists in the project folder, if not it will try to find it where the lintercop dll is located.
If both exists, it will always use the one in the project 