### PR TITLE
Extend Rule0051 on exit() method with Label variable

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0051.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0051.cs
@@ -13,6 +13,7 @@ public class Rule0051
     }
 
     [Test]
+    [TestCase("ExitStatementLabel")]
 #if !LessThenSpring2024
     [TestCase("GetMethodStringLiteral")]
     [TestCase("GetMethodStrSubstNo")]
@@ -29,6 +30,8 @@ public class Rule0051
     }
 
     [Test]
+    [TestCase("ExitStatementLabelWithLocked")]
+    [TestCase("ExitStatementLabelWithMaxLength")]
 #if !LessThenSpring2024
     [TestCase("GetMethodCompanyName")]
     [TestCase("GetMethodStringLiteral")]

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0051/HasDiagnostic/ExitStatementLabel.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0051/HasDiagnostic/ExitStatementLabel.al
@@ -1,0 +1,9 @@
+codeunit 50000 MyCodeunit
+{
+    internal procedure MyProcedure(): Text[10]
+    var
+        MyLabelLbl: Label 'My Label';
+    begin
+        exit([|MyLabelLbl|]);
+end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0051/NoDiagnostic/ExitStatementLabelWithLocked.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0051/NoDiagnostic/ExitStatementLabelWithLocked.al
@@ -1,0 +1,9 @@
+codeunit 50000 MyCodeunit
+{
+    internal procedure MyProcedure(): Text[10]
+    var
+        MyLabelLbl: Label 'My Label', Locked = true;
+    begin
+        exit([|MyLabelLbl|]);
+end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0051/NoDiagnostic/ExitStatementLabelWithMaxLength.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0051/NoDiagnostic/ExitStatementLabelWithMaxLength.al
@@ -1,0 +1,9 @@
+codeunit 50000 MyCodeunit
+{
+    internal procedure MyProcedure(): Text[10]
+    var
+        MyLabelLbl: Label 'My Label', MaxLength = 10;
+    begin
+        exit([|MyLabelLbl|]);
+end;
+}


### PR DESCRIPTION
Fixes: https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/920