### PR TITLE
add Rule0094 no global variables in codeunit

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0094.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0094.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0094
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0094");
+    }
+
+    [Test]
+    [TestCase("GlobalVariableInCodeunit")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0094NoGlobalVariablesInCodeunit>();
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0094NoGlobalVariablesInCodeunit.Id);
+    }
+
+    [Test]
+    [TestCase("GlobalLabel")]
+    [TestCase("GlobalVaraibleInTable")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0094NoGlobalVariablesInCodeunit>();
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0094NoGlobalVariablesInCodeunit.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0094/HasDiagnostic/GlobalVariableInCodeunit.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0094/HasDiagnostic/GlobalVariableInCodeunit.al
@@ -1,0 +1,5 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        [|MyGlobalVariable|]: Boolean;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0094/NoDiagnostic/GlobalLabel.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0094/NoDiagnostic/GlobalLabel.al
@@ -1,0 +1,5 @@
+codeunit 50100 MyCodeunit
+{
+    var
+        [|MyGlobalLabel|]: Label '';
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0094/NoDiagnostic/GlobalVaraibleInTable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0094/NoDiagnostic/GlobalVaraibleInTable.al
@@ -1,0 +1,10 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+
+    var 
+        [|MyGlobalVariable|]: Boolean;
+}

--- a/BusinessCentral.LinterCop/Design/Rule0094NoGlobalVariablesInCodeunit.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0094NoGlobalVariablesInCodeunit.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+
+namespace BusinessCentral.LinterCop.Design;
+
+[DiagnosticAnalyzer]
+public class Rule0094NoGlobalVariablesInCodeunit : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.Rule0094NoGlobalVariablesInCodeunit);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterSymbolAction(
+            new Action<SymbolAnalysisContext>(this.Check),
+            new SymbolKind[]{
+                    SymbolKind.GlobalVariable,
+            }
+        );
+    }
+
+    private void Check(SymbolAnalysisContext ctx)
+    {
+        var containingObject = ctx.Symbol.GetContainingObjectTypeSymbol();
+        if (containingObject.Kind != SymbolKind.Codeunit)
+        {
+            return;
+        }
+
+        if (ctx.Symbol is IVariableSymbol variableDeclaration)
+        {
+            if (variableDeclaration.Type.NavTypeKind == NavTypeKind.Label)
+            {
+                // Global labels are fine.
+                return;
+            }
+
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.Rule0094NoGlobalVariablesInCodeunit,
+                ctx.Symbol.GetLocation(),
+                [ctx.Symbol.Name]
+            ));
+        }
+    }
+}

--- a/BusinessCentral.LinterCop/DiagnosticDescriptors.cs
+++ b/BusinessCentral.LinterCop/DiagnosticDescriptors.cs
@@ -943,4 +943,14 @@ public static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: LinterCopAnalyzers.GetLocalizableString("Rule0091TranslatableTextShouldBeTranslatedDescription"),
         helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0091");
+
+    public static readonly DiagnosticDescriptor Rule0094NoGlobalVariablesInCodeunit = new(
+        id: LinterCopAnalyzers.AnalyzerPrefix + "0094",
+        title: LinterCopAnalyzers.GetLocalizableString("Rule0094NoGlobalVariablesInCodeunitTitle"),
+        messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0094NoGlobalVariablesInCodeunitFormat"),
+        category: "Design",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: LinterCopAnalyzers.GetLocalizableString("Rule0094NoGlobalVariablesInCodeunitDescription"),
+        helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0094");
 }

--- a/BusinessCentral.LinterCop/LinterCop.ruleset.json
+++ b/BusinessCentral.LinterCop/LinterCop.ruleset.json
@@ -451,6 +451,11 @@
       "id": "LC0090",
       "action": "Info",
       "justification": "Show Cognitive Complexity diagnostics for methods above threshold."
+    },
+    {
+      "id": "LC0094",
+      "action": "Info",
+      "justification": "Avoid global variables to reduce hidden coupling and side effects, and to improve testability and maintainability."
     }
   ]
 }

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -954,4 +954,13 @@
   <data name="Rule0091TranslatableTextShouldBeTranslatedDescription" xml:space="preserve">
     <value>Labels and other variants should be translated for every available translation file language.</value>
   </data>
+    <data name="Rule0094NoGlobalVariablesInCodeunitTitle" xml:space="preserve">
+    <value>Avoid global variables in codeunits.</value>
+  </data>
+  <data name="Rule0094NoGlobalVariablesInCodeunitFormat" xml:space="preserve">
+    <value>Codeunit variable \"{0}\" should be local if possible</value>
+  </data>
+  <data name="Rule0094NoGlobalVariablesInCodeunitDescription" xml:space="preserve">
+    <value>Avoid global variables in codeunits to reduce hidden coupling and side effects, and to improve testability and maintainability.</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 |[LC0089](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0089)|Show Cognitive Complexity diagnostics for all methods.|Disabled|
 |[LC0090](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0090)|Show Cognitive Complexity diagnostics for methods above threshold.|Info|
 |[LC0091](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0091)|Translatable texts should be translated|Info|14.0|
+|[LC0094](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0094)|Avoid global variables in codeunits.|Info||
 
 ## Codespace
 


### PR DESCRIPTION
**Description**
Avoid global variables in codeunits unless absolutely necessary. (Exception: Label)

**Reason for this rule**
Avoiding global variables is widely regarded as a best practice. (https://embeddedartistry.com/fieldatlas/the-problems-with-global-variables/)
Global variables hide dependencies, introduce implicit state, and hinder unit-testing and maintenance. Use parameters or local variables to share data instead. 