### PR TITLE
add Rule0095 avoid unneccessary Rec usage

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0095.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0095.cs
@@ -1,0 +1,38 @@
+﻿namespace BusinessCentral.LinterCop.Test;
+
+public class Rule0095
+{
+    private string _testCaseDir = "";
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCaseDir = Path.Combine(Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.FullName,
+            "TestCases", "Rule0095");
+    }
+
+    [Test]
+    [TestCase("UnneccessaryRecUsageCodeunit")]
+    [TestCase("UnneccessaryRecUsageTable")]
+    public async Task HasDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0095AvoidUnneccessaryRecUsage>();
+        fixture.HasDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0095AvoidUnneccessaryRecUsage.Id);
+    }
+
+    [Test]
+    [TestCase("RecUsageInCodeunitWithSourceTable")]
+    [TestCase("RecUsageInEventSubscriber")]
+    [TestCase("RecUsageInPage")]
+    public async Task NoDiagnostic(string testCase)
+    {
+        var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))
+            .ConfigureAwait(false);
+
+        var fixture = RoslynFixtureFactory.Create<Rule0095AvoidUnneccessaryRecUsage>();
+        fixture.NoDiagnosticAtAllMarkers(code, DiagnosticDescriptors.Rule0095AvoidUnneccessaryRecUsage.Id);
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0095/HasDiagnostic/UnneccessaryRecUsageCodeunit.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0095/HasDiagnostic/UnneccessaryRecUsageCodeunit.al
@@ -1,0 +1,23 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure DoSth()
+    begin
+    end;
+}
+
+
+codeunit 50100 MyCodeunit
+{
+    procedure MyProcedure()
+    var
+        Rec: Record MyTable;
+    begin
+        [|Rec|].DoSth();
+        [|Rec|].Name := 'Name';
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0095/HasDiagnostic/UnneccessaryRecUsageTable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0095/HasDiagnostic/UnneccessaryRecUsageTable.al
@@ -1,0 +1,16 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure MyProcedure()
+    begin
+        [|Rec|].DoSth(Rec);
+    end;
+
+    procedure DoSth(MyTable : Record MyTable)
+    begin
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0095/NoDiagnostic/RecUsageInCodeunitWithSourceTable.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0095/NoDiagnostic/RecUsageInCodeunitWithSourceTable.al
@@ -1,0 +1,21 @@
+[|table 50100 MyTable|]
+{
+    fields
+    {
+        field(1; MyField; Integer) {}
+    }
+
+    procedure DoSthTable() 
+    begin
+    end;
+}
+
+page 50100 MyPage
+{
+    PageType = List;
+    SourceTable = MyTable;
+
+    local procedure DoSth() begin
+        [|Rec|].DoSthTable();
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0095/NoDiagnostic/RecUsageInEventSubscriber.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0095/NoDiagnostic/RecUsageInEventSubscriber.al
@@ -1,0 +1,25 @@
+table 50100 MyTable
+{
+    fields
+    {
+        field(1; Name; Text[100]) { }
+    }
+
+    procedure DoSth()
+    begin
+    end;
+}
+
+codeunit 50000 MyCodeunit
+{
+    [IntegrationEvent(false, false)]
+    local procedure MyProcedure(var Rec: Record MyTable; var xRec: Record MyTable)
+    begin
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::MyCodeunit, MyProcedure, '', false, false)]
+    local procedure MyProcedure2(var Rec: Record MyTable; xRec: Record MyTable)
+    begin
+        [|Rec|].DoSth();
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0095/NoDiagnostic/RecUsageInPage.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0095/NoDiagnostic/RecUsageInPage.al
@@ -1,0 +1,19 @@
+table 50100 [|MyTable|]
+{
+    TableType = Temporary;
+
+    fields
+    {
+        field(1; MyField; Integer) { }
+    }
+}
+
+page 50100 MyPage
+{
+    SourceTable = MyTable;
+
+    procedure MyProcedure()
+    begin
+        [|Rec|].MyField := 0;
+    end;
+}

--- a/BusinessCentral.LinterCop/Design/Rule0095AvoidUnneccessaryRecUsage.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0095AvoidUnneccessaryRecUsage.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Immutable;
+using BusinessCentral.LinterCop.Helpers;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace BusinessCentral.LinterCop.Design;
+
+[DiagnosticAnalyzer]
+public class Rule0095AvoidUnneccessaryRecUsage : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(DiagnosticDescriptors.Rule0095AvoidUnneccessaryRecUsage);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterOperationAction(
+            new Action<OperationAnalysisContext>(CheckRecNotUsed),
+            new OperationKind[] {
+                    OperationKind.InvocationExpression,
+                    OperationKind.FieldAccess
+            });
+    }
+
+    private void CheckRecNotUsed(OperationAnalysisContext context)
+    {
+        if (context.ContainingSymbol.GetContainingObjectTypeSymbol().IsObsoletePending ||
+                context.ContainingSymbol.GetContainingObjectTypeSymbol().IsObsoleteRemoved) return;
+        if (context.ContainingSymbol.IsObsoletePending || context.ContainingSymbol.IsObsoleteRemoved) return;
+
+        // In event subscribers "Rec." usage has to be allowed, because variable names have to be taken
+        // over from respective publisher.
+        if (context.ContainingSymbol is IMethodSymbol method && method.IsEventSubscriber())
+        {
+            return;
+        }
+
+        if (context.Operation.Kind == OperationKind.InvocationExpression)
+        {
+            IInvocationExpression operation = (IInvocationExpression)context.Operation;
+            if (operation.Instance == null || !HelperFunctions.IsRecord(operation.Instance.Type))
+                // procedure not called from record -> nothing to check
+                return;
+
+            // In pages everything is allowed -> nothing to check 
+            // in codeunit with source table everything is allowed -> nothing to check
+            if (IsPageOrCodeunitWithSourceTable(context, operation))
+                return;
+
+            var operationInstanceSyntax = operation.Instance.Syntax;
+            if (operationInstanceSyntax.ToString().ToUpper() != "REC")
+                return;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                                        DiagnosticDescriptors.Rule0095AvoidUnneccessaryRecUsage,
+                                        operationInstanceSyntax.GetLocation()));
+        }
+
+        if (context.Operation is IFieldAccess fieldAccess)
+        {
+            if (fieldAccess.Instance == null || !HelperFunctions.IsRecord(fieldAccess.Instance.Type))
+                // not called from record -> nothing to check
+                return;
+
+            // In pages everything is allowed -> nothing to check 
+            // in codeunit with source table everything is allowed -> nothing to check
+            if (IsPageOrCodeunitWithSourceTable(context, fieldAccess))
+                return;
+
+            // field access not from record -> nothing to check
+            if (fieldAccess.Instance.Syntax.ToString().ToUpper() != "REC")
+                return;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.Rule0095AvoidUnneccessaryRecUsage,
+                    fieldAccess.Instance.Syntax.GetLocation()));
+        }
+    }
+
+    private bool IsPageOrCodeunitWithSourceTable(OperationAnalysisContext context, IOperation operation)
+    {
+        if (operation.Syntax.GetContainingObjectSyntax().GetType().ToString().Contains("Page"))
+            return true;
+
+        if (operation.Syntax.GetContainingObjectSyntax().GetType().ToString().Contains("Codeunit"))
+        {
+            if (context.ContainingSymbol.GetContainingObjectTypeSymbol().GetProperty(PropertyKind.TableNo) != null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/BusinessCentral.LinterCop/DiagnosticDescriptors.cs
+++ b/BusinessCentral.LinterCop/DiagnosticDescriptors.cs
@@ -943,4 +943,14 @@ public static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: LinterCopAnalyzers.GetLocalizableString("Rule0091TranslatableTextShouldBeTranslatedDescription"),
         helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0091");
+
+    public static readonly DiagnosticDescriptor Rule0095AvoidUnneccessaryRecUsage = new(
+        id: LinterCopAnalyzers.AnalyzerPrefix + "0095",
+        title: LinterCopAnalyzers.GetLocalizableString("Rule0095AvoidUnneccessaryRecUsageTitle"),
+        messageFormat: LinterCopAnalyzers.GetLocalizableString("Rule0095AvoidUnneccessaryRecUsageFormat"),
+        category: "Design",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: LinterCopAnalyzers.GetLocalizableString("Rule0095AvoidUnneccessaryRecUsageDescription"),
+        helpLinkUri: "https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0095");
 }

--- a/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
+++ b/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
@@ -59,4 +59,7 @@ public class HelperFunctions
         }
         return true;
     }
+
+    public static bool IsRecord(ITypeSymbol symb) =>
+        symb != null && symb.Kind == SymbolKind.Record;
 }

--- a/BusinessCentral.LinterCop/LinterCop.ruleset.json
+++ b/BusinessCentral.LinterCop/LinterCop.ruleset.json
@@ -451,6 +451,11 @@
       "id": "LC0090",
       "action": "Info",
       "justification": "Show Cognitive Complexity diagnostics for methods above threshold."
+    },
+    {
+      "id": "LC0095",
+      "action": "Info",
+      "justification": "\"Rec\" usage only allowed in pages, codeunits with source table and event subscribers."
     }
   ]
 }

--- a/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
+++ b/BusinessCentral.LinterCop/LinterCopAnalyzers.resx
@@ -954,4 +954,13 @@
   <data name="Rule0091TranslatableTextShouldBeTranslatedDescription" xml:space="preserve">
     <value>Labels and other variants should be translated for every available translation file language.</value>
   </data>
+    <data name="Rule0095AvoidUnneccessaryRecUsageTitle" xml:space="preserve">
+    <value>\"Rec\" usage not allowed.</value>
+  </data>
+  <data name="Rule0095AvoidUnneccessaryRecUsageFormat" xml:space="preserve">
+    <value>"\"Rec\" usage only allowed in pages, codeunits with source table and event subscribers".</value>
+  </data>
+  <data name="Rule0095AvoidUnneccessaryRecUsageDescription" xml:space="preserve">
+    <value>"\"Rec\" usage only allowed in pages, codeunits with source table and event subscribers". Outside those contexts \"Rec\" is unnecessary boilerplate.</value>
+  </data>
 </root>

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For an example and the default values see: [LinterCop.ruleset.json](./BusinessCe
 |[LC0089](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0089)|Show Cognitive Complexity diagnostics for all methods.|Disabled|
 |[LC0090](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0090)|Show Cognitive Complexity diagnostics for methods above threshold.|Info|
 |[LC0091](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0091)|Translatable texts should be translated|Info|14.0|
+|[LC0095](https://github.com/StefanMaron/BusinessCentral.LinterCop/wiki/LC0095)|"Rec" usage only allowed in pages, codeunits with source table and event subscribers|Info||
 
 ## Codespace
 


### PR DESCRIPTION
**Description**
Rec should be used only in contexts where it is required by the runtime (pages, codeunits with a SourceTable, and event-subscriber procedures). In other cases Rec adds no value.

**Reason for this rule**
Eliminating unnecessary Rec references keeps the code cleaner/ improves readability .