### PR TITLE
LC0072: Check duplicate parameter and returns documentation

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0072.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0072.cs
@@ -14,6 +14,8 @@ public class Rule0072
     [Test]
     [TestCase("Return")]
     [TestCase("Parameter")]
+    [TestCase("DuplicateParameter")]
+    [TestCase("DuplicateReturns")]
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0072/HasDiagnostic/DuplicateParameter.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0072/HasDiagnostic/DuplicateParameter.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    /// <summary>
+    /// Duplicate documentation parameter.
+    /// </summary>
+    /// <param name="Value">The parameter documentation.</param>
+    /// [|<param name="Value">The duplicate parameter documentation.</param>|]
+    procedure MyProcedure(Value: Boolean)
+    begin
+
+    end;
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0072/HasDiagnostic/DuplicateReturns.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0072/HasDiagnostic/DuplicateReturns.al
@@ -1,0 +1,12 @@
+codeunit 50100 MyCodeunit
+{
+    /// <summary>
+    /// Duplicate documentation returns.
+    /// </summary>
+    /// <returns>A Value.</returns>
+    /// [|<returns>A Value (duplicate).</returns>|]
+    procedure MyProcedure() Value: Boolean
+    begin
+
+    end;
+}

--- a/BusinessCentral.LinterCop/Design/Rule0072CheckProcedureDocumentationComment.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0072CheckProcedureDocumentationComment.cs
@@ -39,8 +39,14 @@ public class Rule0072CheckProcedureDocumentationComment : DiagnosticAnalyzer
                     var parameterName = nameAttribute.Identifier.GetText().ToString();
                     if (!docCommentParameters.ContainsKey(parameterName))
                         docCommentParameters.Add(parameterName, element);
+                    else
+                        // report diagnostic for duplicate parameter documentation
+                        ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0072CheckProcedureDocumentationComment, element.GetLocation()));
                     break;
                 case "returns":
+                    if (docCommentReturns is not null)
+                        // report diagnostic for duplicate returns documentation
+                        ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Rule0072CheckProcedureDocumentationComment, element.GetLocation()));
                     docCommentReturns = element;
                     break;
             }


### PR DESCRIPTION
Fixes #1076 

Checks if a `<parameter>` or `<returns>` element exists multiple times, if so reports the LC0072 diagnostic.
I'm not sure if a separate rule / diagnostic message is needed (since it's technically not a matching syntax issue), this is how the problem would currently appear:
<img width="791" height="232" alt="image" src="https://github.com/user-attachments/assets/3f26323b-4e27-4255-b0e1-08b5e1203d6b" />
