### PR TITLE
Temporarily disable code signing in the CI/CD workflow until issue #1…

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Code Sign artifacts
         id: code-sign
         uses: ./.github/actions/dotnet-sign
+        if: false # Temporary disable code signing until we have resolved issue #1149
         with:
           base-directory: ${{ github.workspace }}\BuildArtifacts
           description: "BusinessCentral.LinterCop"


### PR DESCRIPTION
Fixes: https://github.com/StefanMaron/BusinessCentral.LinterCop/issues/1149