### PR TITLE
Rule0092: Extend naming pattern validation (Captions, Fields, Groups, Actions, API Page Fields)

### DIFF
--- a/BusinessCentral.LinterCop.Test/Rule0092.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0092.cs
@@ -35,7 +35,23 @@ public class Rule0092
                     "variable.name" : {
                         "allow.pattern": "^[A-Z][A-Za-z0-9]*$", // No special characters allowed & must start with upper case letter
                         "disallow.pattern": "^A42.*", // variable and parameter names must not start with A42
-                    }
+                    },
+                    "caption.name" : {
+                        "allow.pattern": "^[A-Z][A-Za-z0-9]*$", // No special characters allowed & must start with upper case letter
+                        "disallow.pattern": "^A42.*", // caption must not start with A42
+                    },
+                    "field.name" : {
+                        "allow.pattern": "^[A-Z][A-Za-z0-9]*$", // No special characters allowed & must start with upper case letter
+                        "disallow.pattern": "^A42.*", // field name must not start with A42
+                    },
+                    "group.name" : {
+                        "allow.pattern": "^[A-Z][A-Za-z0-9]*$", // No special characters allowed & must start with upper case letter
+                        "disallow.pattern": "^A42.*", // group name must not start with A42
+                    },
+                    "action.name" : {
+                        "allow.pattern": "^[A-Z][A-Za-z0-9]*$", // No special characters allowed & must start with upper case letter
+                        "disallow.pattern": "^A42.*", // action name must not start with A42
+                    },
                 }
             """);
 
@@ -59,6 +75,11 @@ public class Rule0092
     [TestCase("ReturnParameterWithSpecialCharacter")]
     [TestCase("VariableWithSpecialCharacter")]
     [TestCase("VariableWithDisallowPattern")]
+    [TestCase("CaptionWithDisallowedChars")]
+    [TestCase("FieldNamesWithSpecialCharacters")]
+    [TestCase("ApiFieldWithSpecialCharacters")]
+    [TestCase("InvalidGroupNames")]
+    [TestCase("InvalidActionNames")]
     public async Task HasDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "HasDiagnostic", $"{testCase}.al"))
@@ -73,6 +94,11 @@ public class Rule0092
     [TestCase("GlobalProcedureWithoutLocalAllowPattern")]
     [TestCase("ObsoleteLowerCaseStart")]
     [TestCase("VariableNameWithoutSpecialCharacters")]
+    [TestCase("CaptionWithoutSpecialCharacters")]
+    [TestCase("FieldNamesWithoutSpecialCharacters")]
+    [TestCase("ValidApiFieldNames")]
+    [TestCase("ValidGroupNames")]
+    [TestCase("ValidActionNames")]
     public async Task NoDiagnostic(string testCase)
     {
         var code = await File.ReadAllTextAsync(Path.Combine(_testCaseDir, "NoDiagnostic", $"{testCase}.al"))

--- a/BusinessCentral.LinterCop.Test/Rule0092.cs
+++ b/BusinessCentral.LinterCop.Test/Rule0092.cs
@@ -96,7 +96,7 @@ public class Rule0092
     [TestCase("VariableNameWithoutSpecialCharacters")]
     [TestCase("CaptionWithoutSpecialCharacters")]
     [TestCase("FieldNamesWithoutSpecialCharacters")]
-    [TestCase("ValidApiFieldNames")]
+    [TestCase("ValidAPIFieldNames")]
     [TestCase("ValidGroupNames")]
     [TestCase("ValidActionNames")]
     public async Task NoDiagnostic(string testCase)

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/ApiFieldWithSpecialCharacters.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/ApiFieldWithSpecialCharacters.al
@@ -1,0 +1,43 @@
+table 50100 "My Table"
+{
+    Caption = 'MyTable';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+page 60101 "My Api Page Invalid"
+{
+    PageType = API;
+    SourceTable = "My Table";
+    APIPublisher = 'contoso';
+    APIGroup = 'test';
+    APIVersion = 'v1.0';
+    EntityName = 'myEntity2';
+    EntitySetName = 'myEntities2';
+    ODataKeyFields = SystemId;
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(Group)
+            {
+                field([|MyField|]; Name) { }          // starts uppercase (invalid)
+                field([|my_field|]; Name) { }         // underscore (invalid)
+                field([|MyField2|]; "No.") { }        // starts uppercase (invalid)
+                field([|my_field2|]; "No.") { }       // underscore (invalid)
+            }
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/CaptionWithDisallowedChars.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/CaptionWithDisallowedChars.al
@@ -1,0 +1,17 @@
+table 50100 "My Table"
+{
+    Caption = [|'My Table!!'|];
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Test; Code[10])
+        {
+            Caption = [|'Test%'|];
+        }
+        field(2; Test2; Code[10])
+        {
+            Caption = [|'A42Test'|];
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/FieldNamesWithSpecialCharacters.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/FieldNamesWithSpecialCharacters.al
@@ -1,0 +1,21 @@
+table 50102 "My Table"
+{
+    Caption = 'MyTable';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; [|testfield|]; Code[10]) // starts with lowercase, violates allow pattern
+        {
+            Caption = 'testfield';
+        }
+        field(2; [|A42Field|]; Code[10]) // starts with A42, violates disallow pattern
+        {
+            Caption = 'A42Field';
+        }
+        field(3; [|Field_With_Special|]; Code[10]) // contains underscore, violates allow pattern
+        {
+            Caption = 'Field_With_Special';
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/InvalidActionNames.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/InvalidActionNames.al
@@ -1,0 +1,14 @@
+page 50101 MyPageInvalid
+{
+    layout { }
+
+    actions
+    {
+        area(Processing)
+        {
+            action([|post|]) { }       // violates allow (must start uppercase)
+            action([|A42Run|]) { }     // violates disallow (^A42)
+            action([|Run_Action|]) { } // underscore not allowed
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/InvalidGroupNames.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/HasDiagnostic/InvalidGroupNames.al
@@ -1,0 +1,12 @@
+page 51001 GroupInvalid
+{
+    layout
+    {
+        area(content)
+        {
+            group([|general|]) { }    // lowercase start
+            group([|A42Stuff|]) { }   // disallow ^A42
+            group([|Group_Test|]) { } // underscore
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/CaptionWithoutSpecialCharacters.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/CaptionWithoutSpecialCharacters.al
@@ -1,0 +1,13 @@
+table 50100 "My Table"
+{
+    Caption = [|'MyTable'|];
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Test; Code[10])
+        {
+            Caption = [|'Test'|];
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/FieldNamesWithoutSpecialCharacters.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/FieldNamesWithoutSpecialCharacters.al
@@ -1,0 +1,17 @@
+table 50101 "My Table"
+{
+    Caption = 'MyTable';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; [|TestField|]; Code[10])
+        {
+            Caption = 'TestField';
+        }
+        field(2; [|AnotherField2|]; Code[10])
+        {
+            Caption = 'AnotherField2';
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/ValidAPIFieldNames.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/ValidAPIFieldNames.al
@@ -1,0 +1,41 @@
+table 50100 "My Table"
+{
+    Caption = 'MyTable';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+page 60100 "My Api Page Valid"
+{
+    PageType = API;
+    SourceTable = "My Table";
+    APIPublisher = 'contoso';
+    APIGroup = 'test';
+    APIVersion = 'v1.0';
+    EntityName = 'myEntity';
+    EntitySetName = 'myEntities';
+    ODataKeyFields = SystemId;
+    DelayedInsert = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(Group)
+            {
+                field([|myfield|]; Name) { }
+                field([|myField1|]; "No.") { }
+            }
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/ValidActionNames.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/ValidActionNames.al
@@ -1,0 +1,12 @@
+page 50100 MyPage
+{
+    layout { }
+
+    actions
+    {
+        area(Processing)
+        {
+            action([|Post|]) { }
+        }
+    }
+}

--- a/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/ValidGroupNames.al
+++ b/BusinessCentral.LinterCop.Test/TestCases/Rule0092/NoDiagnostic/ValidGroupNames.al
@@ -1,0 +1,11 @@
+page 51000 GroupValid
+{
+    layout
+    {
+        area(content)
+        {
+            group([|General|]) { }
+            group([|Group1|]) { }
+        }
+    }
+}

--- a/BusinessCentral.LinterCop/Helpers/LinterSettings.cs
+++ b/BusinessCentral.LinterCop/Helpers/LinterSettings.cs
@@ -15,6 +15,10 @@ namespace BusinessCentral.LinterCop.Helpers
         public string WorkingDir = "";
         public ProcedureNamePattern procedureNamePattern = new();
         public VariableAndParameterNamePattern variableAndParameterNamePattern = new();
+        public CaptionPattern captionNamePattern = new();
+        public FieldPattern fieldNamePattern = new();
+        public GroupNamePattern groupNamePattern = new();
+        public ActionNamePattern actionNamePattern = new();
         static public LinterSettings instance;
 
         static public void Create(string WorkingDir)
@@ -50,6 +54,14 @@ namespace BusinessCentral.LinterCop.Helpers
                         instance.procedureNamePattern = internalInstance.procedureNamePattern;
                     if (internalInstance.variableAndParameterNamePattern != null)
                         instance.variableAndParameterNamePattern = internalInstance.variableAndParameterNamePattern;
+                    if (internalInstance.captionNamePattern != null)
+                        instance.captionNamePattern = internalInstance.captionNamePattern;
+                    if (internalInstance.fieldNamePattern != null)
+                        instance.fieldNamePattern = internalInstance.fieldNamePattern;
+                    if (internalInstance.groupNamePattern != null)
+                        instance.groupNamePattern = internalInstance.groupNamePattern;
+                    if (internalInstance.actionNamePattern != null)
+                        instance.actionNamePattern = internalInstance.actionNamePattern;
                 }
 
                 instance.WorkingDir = WorkingDir;
@@ -70,6 +82,18 @@ namespace BusinessCentral.LinterCop.Helpers
 
             [JsonProperty("variable.name")]
             public VariableAndParameterNamePattern variableAndParameterNamePattern = new();
+
+            [JsonProperty("caption.name")]
+            public CaptionPattern captionNamePattern = new();
+
+            [JsonProperty("field.name")]
+            public FieldPattern fieldNamePattern = new();
+
+            [JsonProperty("group.name")]
+            public GroupNamePattern groupNamePattern= new();
+            
+            [JsonProperty("action.name")]
+            public ActionNamePattern actionNamePattern = new();
         }
 
         public class ProcedureNamePattern
@@ -103,6 +127,42 @@ namespace BusinessCentral.LinterCop.Helpers
         }
 
         public class VariableAndParameterNamePattern
+        {
+            [JsonProperty("allow.pattern")]
+            public string AllowPattern = "";
+
+            [JsonProperty("disallow.pattern")]
+            public string DisallowPattern = "";
+        }
+
+        public class CaptionPattern
+        {
+            [JsonProperty("allow.pattern")]
+            public string AllowPattern = "";
+
+            [JsonProperty("disallow.pattern")]
+            public string DisallowPattern = "";
+        }
+
+        public class FieldPattern
+        {
+            [JsonProperty("allow.pattern")]
+            public string AllowPattern = "";
+
+            [JsonProperty("disallow.pattern")]
+            public string DisallowPattern = "";
+        }
+
+        public class GroupNamePattern
+        {
+            [JsonProperty("allow.pattern")]
+            public string AllowPattern = "";
+
+            [JsonProperty("disallow.pattern")]
+            public string DisallowPattern = "";
+        }
+        
+        public class ActionNamePattern
         {
             [JsonProperty("allow.pattern")]
             public string AllowPattern = "";


### PR DESCRIPTION
**Description**
Extends Rule0092 with additional name pattern validations. In addition to procedure, variable, and parameter names, the analyzer now enforces configurable allow / disallow regex patterns for:

- Captions
- field names (Table, Page)
- Group names
- Action names
- It also adds a fixed (non‑configurable) rule for API page field control names (pattern: ^[a-z][A-Za-z0-9]*$ – lower camelCase, alphanumeric only // See: https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-api-pagetype#naming-conventions).

**Reason for this rule**
Improve readability and enforce consistent, project-specific naming conventions.