### PR TITLE
LC0091 Workspace Context

### DIFF
--- a/BusinessCentral.LinterCop/Design/Rule0091TranslatableTextShouldBeTranslated.cs
+++ b/BusinessCentral.LinterCop/Design/Rule0091TranslatableTextShouldBeTranslated.cs
@@ -147,8 +147,11 @@ public class Rule0091TranslatableTextShouldBeTranslated : DiagnosticAnalyzer
     private IEnumerable<Stream> ReadXliffFiles(Compilation compilation)
     {
         IEnumerable<Stream> xliffFileStream = [];
-        IFileSystem fileSystem = new FileSystem();
         NavAppManifest? manifest = ManifestHelper.GetManifest(compilation);
+
+        // use compilation.FileSystem to ensure correct app context (multi-app workspaces).
+        // instantiating FileSystem() directly may default to the first app's directory in multi-app workspaces
+        IFileSystem fileSystem = compilation.FileSystem ?? new FileSystem();
 
         if (manifest == null) return xliffFileStream;
         if (!manifest.CompilerFeatures.ShouldGenerateTranslationFile()) return xliffFileStream;


### PR DESCRIPTION
fixes #1133

Did a bit of debugging and it seems the problem described in the issue has the following cause:
When in a VS Code workspace with multiple apps, creating a `new FileSystem()` may refer to the wrong directory, i suspect it is always the first app's directory in the workspace.
This may result in the wrong app's translation files being compared, which diagnoses all translations as missing, and also since the translation file name does not match the app name, the `.g.xlf` is also evaluated as missing en-US translations.
Using the `compilation.FileSystem` seems to refer to the correct directory for each workspace app and fixes the issue for me.

Unfortunatly i have no idea how to provide a test case for this fix with translations and workspace apps. If anyone has some hints how to test this i can try to add one.