### PR TITLE
Fix: Check if method implements any interface method from the codeunit's interface or interfaces it extends

### DIFF
--- a/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
+++ b/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
@@ -38,6 +38,7 @@ public class HelperFunctions
         {
             return true;
         }
+#if !LessThenFall2024
         foreach (var extendedInterface in interfaceTypeSymbol.ExtendedInterfaces)
         {
             if (MethodImplementsInterfaceMethod(extendedInterface, methodSymbol))
@@ -45,6 +46,7 @@ public class HelperFunctions
                 return true;
             }
         }
+#endif
 
         return false;
     }

--- a/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
+++ b/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
@@ -14,7 +14,7 @@ public class HelperFunctions
         return MethodImplementsInterfaceMethod(methodSymbol.GetContainingApplicationObjectTypeSymbol(), methodSymbol);
     }
 
-    public static bool MethodImplementsInterfaceMethod(IApplicationObjectTypeSymbol objectSymbol, IMethodSymbol methodSymbol)
+    public static bool MethodImplementsInterfaceMethod(IApplicationObjectTypeSymbol? objectSymbol, IMethodSymbol methodSymbol)
     {
         if (objectSymbol is not ICodeunitTypeSymbol codeunitSymbol)
         {

--- a/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
+++ b/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Dynamics.Nav.CodeAnalysis;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using System.Text.RegularExpressions;
 using Microsoft.Dynamics.Nav.CodeAnalysis.Text;

--- a/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
+++ b/BusinessCentral.LinterCop/Helpers/HelperFunctions.cs
@@ -13,7 +13,7 @@ public class HelperFunctions
         return MethodImplementsInterfaceMethod(methodSymbol.GetContainingApplicationObjectTypeSymbol(), methodSymbol);
     }
 
-    public static bool MethodImplementsInterfaceMethod(IApplicationObjectTypeSymbol? objectSymbol, IMethodSymbol methodSymbol)
+    public static bool MethodImplementsInterfaceMethod(IApplicationObjectTypeSymbol objectSymbol, IMethodSymbol methodSymbol)
     {
         if (objectSymbol is not ICodeunitTypeSymbol codeunitSymbol)
         {
@@ -22,7 +22,24 @@ public class HelperFunctions
 
         foreach (var implementedInterface in codeunitSymbol.ImplementedInterfaces)
         {
-            if (implementedInterface.GetMembers().OfType<IMethodSymbol>().Any(interfaceMethodSymbol => MethodImplementsInterfaceMethod(methodSymbol, interfaceMethodSymbol)))
+            if (MethodImplementsInterfaceMethod(implementedInterface, methodSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool MethodImplementsInterfaceMethod(IInterfaceTypeSymbol interfaceTypeSymbol, IMethodSymbol methodSymbol)
+    {
+        if (interfaceTypeSymbol.GetMembers().OfType<IMethodSymbol>().Any(interfaceMethodSymbol => MethodImplementsInterfaceMethod(methodSymbol, interfaceMethodSymbol)))
+        {
+            return true;
+        }
+        foreach (var extendedInterface in interfaceTypeSymbol.ExtendedInterfaces)
+        {
+            if (MethodImplementsInterfaceMethod(extendedInterface, methodSymbol))
             {
                 return true;
             }


### PR DESCRIPTION
Fix: Check if method implements any interface method from the codeunit's interface or interfaces it extends.
The method did not account for `ISomeInterface extends ISomeBaseInterface`, because that wasn't available with older runtimes.

This fixes false positives from LC0052 and LC0053 which check for unused internal procedures.